### PR TITLE
Client - Split RV & TO1. Support multiple rendezvous servers

### DIFF
--- a/integration/test.sh
+++ b/integration/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cd integration/testdata
 

--- a/integration/testdata/rendezvous-info.yml
+++ b/integration/testdata/rendezvous-info.yml
@@ -3,3 +3,7 @@
   device_port: 8081
   owner_port: 8081
   protocol: http
+- dns: localhost
+  device_port: 8082
+  owner_port: 8082
+  protocol: http


### PR DESCRIPTION
Related to #8, will make easier implementing the retries.

Changes:
- Support for multiple rendezvous servers in the config file, and rename `get_client` to `get_client_list`.
- Split `get_to1d_from_rv` into `get_rv_info` and `get_to1d`.
- In the testing part:
  - Add `-e` flag in `integration/test.sh`.
  - Add one more rendezvous server (that won't be operating, just for the sake of dealing with multiple RV servers) in `integration/testdata/rendezvous-info.yml`.