### PR TITLE
Settings change

### DIFF
--- a/owner-onboarding-service/src/main.rs
+++ b/owner-onboarding-service/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
 
     let mut settings = config::Config::default();
     settings
-        .merge(config::File::with_name("owner-onboarding-service"))
+        .merge(config::File::with_name("owner-onboarding-service").required(false))
         .context("Loading configuration files")?
         .merge(config::Environment::with_prefix("owner-onboarding-service"))
         .context("Loading configuration from environment variables")?;

--- a/owner-onboarding-service/src/main.rs
+++ b/owner-onboarding-service/src/main.rs
@@ -131,7 +131,7 @@ async fn main() -> Result<()> {
     settings
         .merge(config::File::with_name("owner-onboarding-service").required(false))
         .context("Loading configuration files")?
-        .merge(config::Environment::with_prefix("owner-onboarding-service"))
+        .merge(config::Environment::with_prefix("owner_onboarding_service"))
         .context("Loading configuration from environment variables")?;
     let settings: Settings = settings.try_into().context("Error parsing configuration")?;
 

--- a/rendezvous-server/src/main.rs
+++ b/rendezvous-server/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
 
     let mut settings = config::Config::default();
     settings
-        .merge(config::File::with_name("rendezvous-service"))
+        .merge(config::File::with_name("rendezvous-service").required(false))
         .context("Loading configuration files")?
         .merge(config::Environment::with_prefix("rendezvous"))
         .context("Loading configuration from environment variables")?;


### PR DESCRIPTION
- Moving configuration file to be optional will make it easier on deployments, also will make it easier by the user to catch the
configuration he's missing.
- Change prefix to fit bash/zsh export.