### PR TITLE
Make message ordering and encryption stronger

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -18,6 +18,8 @@ serde_tuple = "0.5"
 thiserror = "1"
 aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
 uuid = "0.8"
+num-traits = "0.2"
+num-derive = "0.2"
 
 http = "0.2"
 hyper = "0.14"

--- a/data-formats/src/errors.rs
+++ b/data-formats/src/errors.rs
@@ -3,6 +3,16 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
+pub enum ChainError {
+    #[error("Chain is empty")]
+    Empty,
+    #[error("Invalid signed certificate at position {0}")]
+    InvalidSignedCert(usize),
+    #[error("No trusted root encountered")]
+    NoTrustedRoot,
+}
+
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
     #[error("Cryptographic error stack: {0}")]
@@ -29,4 +39,6 @@ pub enum Error {
     InvalidEntryNum,
     #[error("Error in key exchange: {0}")]
     KeyExchangeError(&'static str),
+    #[error("Invalid certificate chain encountered: {0}")]
+    InvalidChain(ChainError),
 }

--- a/data-formats/src/messages/di.rs
+++ b/data-formats/src/messages/di.rs
@@ -1,8 +1,11 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize, Serializer};
 use serde_tuple::Serialize_tuple;
 
-use super::Message;
-use crate::types::CborSimpleType;
+use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
+use crate::{
+    constants::MessageType,
+    types::{CborSimpleType, HMac},
+};
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct AppStart {
@@ -14,37 +17,123 @@ impl AppStart {
         AppStart { mfg_info }
     }
 
-    pub fn get_mfg_info(&self) -> &CborSimpleType {
+    pub fn mfg_info(&self) -> &CborSimpleType {
         &self.mfg_info
     }
 }
 
 impl Message for AppStart {
-    fn message_type() -> u8 {
-        10
+    fn message_type() -> MessageType {
+        MessageType::DIAppStart
+    }
+
+    fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
+        matches!(message_type, None | Some(MessageType::DIUNDone))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        None
     }
 }
+
+impl ClientMessage for AppStart {}
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct SetCredentials {
-    //ov_header: OwnershipVoucherHeader,
-    ov_header: u8,
+    ov_header: Vec<u8>,
 }
 
 impl SetCredentials {
-    //pub fn new(ov_header: OwnershipVoucherHeader) -> Self {
-    pub fn new(ov_header: u8) -> Self {
+    pub fn new(ov_header: Vec<u8>) -> Self {
         SetCredentials { ov_header }
     }
 
-    //pub fn get_ov_header(&self) -> &OwnershipVoucherHeader {
-    pub fn get_ov_header(&self) -> u8 {
-        self.ov_header
+    pub fn ov_header(&self) -> &[u8] {
+        &self.ov_header
     }
 }
 
 impl Message for SetCredentials {
-    fn message_type() -> u8 {
-        11
+    fn message_type() -> MessageType {
+        MessageType::DISetCredentials
+    }
+
+    fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::DIAppStart))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        None
+    }
+}
+
+impl ServerMessage for SetCredentials {}
+
+#[derive(Debug, Serialize_tuple, Deserialize)]
+pub struct SetHMAC {
+    hmac: HMac,
+}
+
+impl SetHMAC {
+    pub fn new(hmac: HMac) -> Self {
+        SetHMAC { hmac }
+    }
+
+    pub fn hmac(&self) -> &HMac {
+        &self.hmac
+    }
+}
+
+impl Message for SetHMAC {
+    fn message_type() -> MessageType {
+        MessageType::DISetHMAC
+    }
+
+    fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::DISetCredentials))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        None
+    }
+}
+
+impl ClientMessage for SetHMAC {}
+
+#[derive(Debug, Deserialize)]
+pub struct Done {}
+
+#[allow(clippy::new_without_default)]
+impl Done {
+    pub fn new() -> Self {
+        Done {}
+    }
+}
+
+impl Message for Done {
+    fn message_type() -> MessageType {
+        MessageType::DIDone
+    }
+
+    fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::DISetHMAC))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        None
+    }
+}
+
+impl ServerMessage for Done {}
+
+// We can't use Serialize_tuple here because that doesn't work for empty things
+impl Serialize for Done {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let seq = serializer.serialize_seq(Some(0))?;
+        seq.end()
     }
 }

--- a/data-formats/src/messages/error.rs
+++ b/data-formats/src/messages/error.rs
@@ -1,52 +1,66 @@
 use serde::{Deserialize, Serialize};
 
-use super::{ClientMessage, Message, ServerMessage};
+use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
 
-use crate::constants::ErrorCode;
+use crate::constants::{ErrorCode, MessageType};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ErrorMessage(ErrorCode, u8, String, Option<serde_cbor::Value>, u128);
+pub struct ErrorMessage {
+    error_code: ErrorCode,
+    previous_message_type: MessageType,
+    error_string: String,
+    error_timestamp: Option<serde_cbor::Value>,
+    error_uuid: u128,
+}
 
 impl ErrorMessage {
     pub fn new(
         error_code: ErrorCode,
-        previous_message_id: u8,
+        previous_message_type: MessageType,
         error_string: String,
         error_uuid: u128,
     ) -> Self {
-        ErrorMessage(
+        ErrorMessage {
             error_code,
-            previous_message_id,
+            previous_message_type,
             error_string,
-            None,
+            error_timestamp: None,
             error_uuid,
-        )
+        }
     }
 
     pub fn error_code(&self) -> ErrorCode {
-        self.0
+        self.error_code
     }
 
-    pub fn previous_message_id(&self) -> u8 {
-        self.1
+    pub fn previous_message_type(&self) -> MessageType {
+        self.previous_message_type
     }
 
     pub fn error_string(&self) -> &str {
-        &self.2
+        &self.error_string
     }
 
     pub fn error_timestamp(&self) -> Option<&serde_cbor::Value> {
-        self.3.as_ref()
+        self.error_timestamp.as_ref()
     }
 
     pub fn error_uuid(&self) -> u128 {
-        self.4
+        self.error_uuid
     }
 }
 
 impl Message for ErrorMessage {
-    fn message_type() -> u8 {
-        255
+    fn message_type() -> MessageType {
+        MessageType::Error
+    }
+
+    fn is_valid_previous_message(_message_type: Option<MessageType>) -> bool {
+        true
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        None
     }
 
     fn status_code() -> http::StatusCode {

--- a/data-formats/src/messages/mod.rs
+++ b/data-formats/src/messages/mod.rs
@@ -2,7 +2,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::constants::ErrorCode;
+use crate::constants::{ErrorCode, MessageType};
 
 mod error;
 pub use error::ErrorMessage;
@@ -23,8 +23,18 @@ pub enum ParseError {
     InvalidBody,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum EncryptionRequirement {
+    MustBeEncrypted,
+    MustNotBeEncrypted,
+}
+
 pub trait Message: Send + Serialize + DeserializeOwned + Sized {
-    fn message_type() -> u8;
+    fn message_type() -> MessageType;
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool;
+
+    fn encryption_requirement() -> Option<EncryptionRequirement>;
 
     fn to_wire(&self) -> Result<Vec<u8>, ParseError> {
         Ok(serde_cbor::to_vec(&self)?)

--- a/data-formats/src/messages/to0.rs
+++ b/data-formats/src/messages/to0.rs
@@ -1,9 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_tuple::Serialize_tuple;
 
-use super::{ClientMessage, Message, ServerMessage};
+use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
 
-use crate::types::{COSESign, Nonce, TO0Data};
+use crate::{
+    constants::MessageType,
+    types::{COSESign, Nonce, TO0Data},
+};
 
 #[derive(Debug, Deserialize)]
 pub struct Hello {}
@@ -16,8 +19,16 @@ impl Hello {
 }
 
 impl Message for Hello {
-    fn message_type() -> u8 {
-        20
+    fn message_type() -> MessageType {
+        MessageType::TO0Hello
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, None)
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -50,8 +61,16 @@ impl HelloAck {
 }
 
 impl Message for HelloAck {
-    fn message_type() -> u8 {
-        21
+    fn message_type() -> MessageType {
+        MessageType::TO0HelloAck
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO0Hello))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -78,8 +97,16 @@ impl OwnerSign {
 }
 
 impl Message for OwnerSign {
-    fn message_type() -> u8 {
-        22
+    fn message_type() -> MessageType {
+        MessageType::TO0OwnerSign
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO0HelloAck))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -101,8 +128,16 @@ impl AcceptOwner {
 }
 
 impl Message for AcceptOwner {
-    fn message_type() -> u8 {
-        23
+    fn message_type() -> MessageType {
+        MessageType::TO0AcceptOwner
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO0OwnerSign))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 

--- a/data-formats/src/messages/to1.rs
+++ b/data-formats/src/messages/to1.rs
@@ -1,9 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_tuple::Serialize_tuple;
 
-use super::{ClientMessage, Message, ServerMessage};
+use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
 
-use crate::types::{COSESign, Guid, Nonce, SigInfo};
+use crate::{
+    constants::MessageType,
+    types::{COSESign, Guid, Nonce, SigInfo},
+};
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct HelloRV {
@@ -29,8 +32,16 @@ impl HelloRV {
 }
 
 impl Message for HelloRV {
-    fn message_type() -> u8 {
-        30
+    fn message_type() -> MessageType {
+        MessageType::TO1HelloRV
+    }
+
+    fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
+        matches!(message_type, None)
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -60,8 +71,16 @@ impl HelloRVAck {
 }
 
 impl Message for HelloRVAck {
-    fn message_type() -> u8 {
-        31
+    fn message_type() -> MessageType {
+        MessageType::TO1HelloRVAck
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO1HelloRV))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -81,8 +100,16 @@ impl ProveToRV {
 }
 
 impl Message for ProveToRV {
-    fn message_type() -> u8 {
-        32
+    fn message_type() -> MessageType {
+        MessageType::TO1ProveToRV
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO1HelloRVAck))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -106,8 +133,16 @@ impl RVRedirect {
 }
 
 impl Message for RVRedirect {
-    fn message_type() -> u8 {
-        33
+    fn message_type() -> MessageType {
+        MessageType::TO1RVRedirect
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO1ProveToRV))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 

--- a/data-formats/src/messages/to2.rs
+++ b/data-formats/src/messages/to2.rs
@@ -1,9 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_tuple::Serialize_tuple;
 
-use super::{ClientMessage, Message, ServerMessage};
+use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
 
-use crate::types::{COSESign, CipherSuite, Guid, HMac, KexSuite, Nonce, ServiceInfo, SigInfo};
+use crate::{
+    constants::MessageType,
+    types::{COSESign, CipherSuite, Guid, HMac, KexSuite, Nonce, ServiceInfo, SigInfo},
+};
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct HelloDevice {
@@ -53,8 +56,16 @@ impl HelloDevice {
 }
 
 impl Message for HelloDevice {
-    fn message_type() -> u8 {
-        60
+    fn message_type() -> MessageType {
+        MessageType::TO2HelloDevice
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, None)
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -74,8 +85,16 @@ impl ProveOVHdr {
 }
 
 impl Message for ProveOVHdr {
-    fn message_type() -> u8 {
-        61
+    fn message_type() -> MessageType {
+        MessageType::TO2ProveOVHdr
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2HelloDevice))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -97,8 +116,19 @@ impl GetOVNextEntry {
 }
 
 impl Message for GetOVNextEntry {
-    fn message_type() -> u8 {
-        62
+    fn message_type() -> MessageType {
+        MessageType::TO2GetOVNextEntry
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(
+            message_type,
+            Some(MessageType::TO2ProveOVHdr) | Some(MessageType::TO2OVNextEntry)
+        )
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -125,8 +155,16 @@ impl OVNextEntry {
 }
 
 impl Message for OVNextEntry {
-    fn message_type() -> u8 {
-        63
+    fn message_type() -> MessageType {
+        MessageType::TO2OVNextEntry
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2GetOVNextEntry))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -146,8 +184,16 @@ impl ProveDevice {
 }
 
 impl Message for ProveDevice {
-    fn message_type() -> u8 {
-        64
+    fn message_type() -> MessageType {
+        MessageType::TO2ProveDevice
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2OVNextEntry))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustNotBeEncrypted)
     }
 }
 
@@ -167,8 +213,16 @@ impl SetupDevice {
 }
 
 impl Message for SetupDevice {
-    fn message_type() -> u8 {
-        65
+    fn message_type() -> MessageType {
+        MessageType::TO2SetupDevice
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2ProveDevice))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -198,8 +252,16 @@ impl DeviceServiceInfoReady {
 }
 
 impl Message for DeviceServiceInfoReady {
-    fn message_type() -> u8 {
-        66
+    fn message_type() -> MessageType {
+        MessageType::TO2DeviceServiceInfoReady
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2SetupDevice))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -223,8 +285,16 @@ impl OwnerServiceInfoReady {
 }
 
 impl Message for OwnerServiceInfoReady {
-    fn message_type() -> u8 {
-        67
+    fn message_type() -> MessageType {
+        MessageType::TO2OwnerServiceInfoReady
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2DeviceServiceInfoReady))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -254,8 +324,19 @@ impl DeviceServiceInfo {
 }
 
 impl Message for DeviceServiceInfo {
-    fn message_type() -> u8 {
-        68
+    fn message_type() -> MessageType {
+        MessageType::TO2DeviceServiceInfo
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(
+            message_type,
+            Some(MessageType::TO2OwnerServiceInfoReady) | Some(MessageType::TO2OwnerServiceInfo)
+        )
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -291,8 +372,16 @@ impl OwnerServiceInfo {
 }
 
 impl Message for OwnerServiceInfo {
-    fn message_type() -> u8 {
-        69
+    fn message_type() -> MessageType {
+        MessageType::TO2OwnerServiceInfo
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2DeviceServiceInfo))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -314,8 +403,16 @@ impl Done {
 }
 
 impl Message for Done {
-    fn message_type() -> u8 {
-        70
+    fn message_type() -> MessageType {
+        MessageType::TO2Done
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2OwnerServiceInfo))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 
@@ -337,8 +434,16 @@ impl Done2 {
 }
 
 impl Message for Done2 {
-    fn message_type() -> u8 {
-        71
+    fn message_type() -> MessageType {
+        MessageType::TO2Done2
+    }
+
+    fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
+        matches!(message_type, Some(MessageType::TO2Done))
+    }
+
+    fn encryption_requirement() -> Option<EncryptionRequirement> {
+        Some(EncryptionRequirement::MustBeEncrypted)
     }
 }
 

--- a/http-wrapper/src/lib.rs
+++ b/http-wrapper/src/lib.rs
@@ -24,6 +24,14 @@ impl EncryptionKeys {
         }
     }
 
+    pub fn is_none(&self) -> bool {
+        self.cipher_suite.is_none() || self.keys.is_none()
+    }
+
+    pub fn is_some(&self) -> bool {
+        !self.is_none()
+    }
+
     pub fn from_derived(cipher_suite: CipherSuite, derived_keys: DerivedKeys) -> Self {
         EncryptionKeys {
             cipher_suite: Some(cipher_suite),

--- a/owner-onboarding-service/src/main.rs
+++ b/owner-onboarding-service/src/main.rs
@@ -155,7 +155,8 @@ async fn main() -> Result<()> {
         })?;
         X509::stack_from_pem(&contents).context("Error parsing trusted device keys")?
     };
-    let trusted_device_keys = X5Bag::new(trusted_device_keys);
+    let trusted_device_keys = X5Bag::with_certs(trusted_device_keys)
+        .context("Error building trusted device keys X5Bag")?;
 
     // Our private key
     let owner_key = load_private_key(&settings.owner_private_key_path).with_context(|| {

--- a/rendezvous-server/src/main.rs
+++ b/rendezvous-server/src/main.rs
@@ -116,7 +116,8 @@ async fn main() -> Result<()> {
         })?;
         X509::stack_from_pem(&contents).context("Error parsing trusted manufacturer keys")?
     };
-    let trusted_manufacturer_keys = X5Bag::new(trusted_manufacturer_keys);
+    let trusted_manufacturer_keys = X5Bag::with_certs(trusted_manufacturer_keys)
+        .context("Error building trusted manufacturer keys X5Bag")?;
     let trusted_device_keys = {
         let trusted_keys_path = settings.trusted_device_keys_path;
         let contents = std::fs::read(&trusted_keys_path).with_context(|| {
@@ -127,7 +128,8 @@ async fn main() -> Result<()> {
         })?;
         X509::stack_from_pem(&contents).context("Error parsing trusted device keys")?
     };
-    let trusted_device_keys = X5Bag::new(trusted_device_keys);
+    let trusted_device_keys = X5Bag::with_certs(trusted_device_keys)
+        .context("Error building trusted device keys X5Bag")?;
 
     // Initialize handler stores
     let user_data = Arc::new(RendezvousUD {


### PR DESCRIPTION
This enforces the ordering of messages within a session, by making both
the client and server check whether the next message is allowed at this
place of the protocol.
This would avoid possible issues where an attacker skips a part of the
process, skipping to the next part of the code.

This patch also includes metadata on the messages whether they're
required to be encrypted, which is checked by client and server.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>