### PR TITLE
Fix PublicKey data structure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-redhat.sh")" -- "true" "vscode" "1000" "1000" "true"
 
 RUN dnf install -y \
-    sudo git cargo rust rust-src openssl-devel clippy cargo-fmt \
+    sudo git cargo rust rust-src openssl-devel clippy rustfmt \
     && dnf clean all
 
 USER vscode

--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -324,14 +324,13 @@ async fn perform_to2(
     log::trace!("Got owner entry: {:?}", ov_owner_entry);
 
     // Now, we can finally verify the OV Header signature we got at the top!
-    let owner_pubkey = ov_owner_entry
-        .public_key
-        .as_pkey()
-        .context("Error parsing owner public key")?;
     let prove_ov_hdr_payload: TO2ProveOVHdrPayload = prove_ov_hdr
-        .get_payload(&owner_pubkey)
+        .get_payload(ov_owner_entry.public_key.pkey())
         .context("Error validating ProveOVHdr signature")?;
-    log::trace!("ProveOVHdr validated with public key: {:?}", owner_pubkey);
+    log::trace!(
+        "ProveOVHdr validated with public key: {:?}",
+        ov_owner_entry.public_key
+    );
 
     // Perform the key derivation
     let a_key_exchange = prove_ov_hdr_payload.a_key_exchange();

--- a/data-formats/src/errors.rs
+++ b/data-formats/src/errors.rs
@@ -10,6 +10,8 @@ pub enum ChainError {
     InvalidSignedCert(usize),
     #[error("No trusted root encountered")]
     NoTrustedRoot,
+    #[error("Non-issuer certificate at position {0}")]
+    NonIssuer(usize),
 }
 
 #[derive(Error, Debug)]

--- a/data-formats/src/ownershipvoucher.rs
+++ b/data-formats/src/ownershipvoucher.rs
@@ -218,8 +218,7 @@ impl<'a> EntryIter<'a> {
 
     fn process_element(&mut self, element: &'a [u8]) -> Result<OwnershipVoucherEntryPayload> {
         let entry = COSESign::from_bytes(element)?;
-        let key = self.pubkey.as_pkey()?;
-        let entry: OwnershipVoucherEntryPayload = entry.get_payload(&key)?;
+        let entry: OwnershipVoucherEntryPayload = entry.get_payload(self.pubkey.pkey())?;
 
         // Compare the HashPreviousEntry to either (HeaderTag || HeaderHmac) or the previous entry
         let mut hdr_hash =

--- a/data-formats/src/publickey.rs
+++ b/data-formats/src/publickey.rs
@@ -5,8 +5,8 @@ use std::fmt::Display;
 
 use openssl::{
     nid::Nid,
-    pkey::{PKey, PKeyRef, Public},
-    x509::X509,
+    pkey::{self, PKey, PKeyRef, Public},
+    x509::{X509Ref, X509VerifyResult, X509},
 };
 use serde::Deserialize;
 use serde_tuple::Serialize_tuple;
@@ -18,124 +18,147 @@ use crate::{
     types::Hash,
 };
 
-#[derive(Debug, Clone, Serialize_tuple, Deserialize)]
+#[derive(Debug, Clone, Serialize_tuple)]
 pub struct PublicKey {
     key_type: PublicKeyType,
     encoding: PublicKeyEncoding,
     data: Vec<u8>,
+
+    #[serde(skip)]
+    pkey: PKey<Public>,
+}
+
+impl<'de> Deserialize<'de> for PublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<PublicKey, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct PublicKeyVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
+            type Value = PublicKey;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a tuple of (PublicKeyType, PublicKeyEncoding, Vec<u8>)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let key_type: PublicKeyType = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let encoding: PublicKeyEncoding = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                let data: Vec<u8> = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
+
+                PublicKey::new(key_type, encoding, data).map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_tuple(3, PublicKeyVisitor)
+    }
 }
 
 impl PublicKey {
-    pub fn new(keytype: PublicKeyType, body: PublicKeyBody) -> Result<Self> {
-        match body {
-            PublicKeyBody::Crypto(v) => Ok(PublicKey {
-                key_type: keytype,
-                encoding: PublicKeyEncoding::Crypto,
-                data: v,
-            }),
-            PublicKeyBody::X509(v) => Ok(PublicKey {
-                key_type: keytype,
-                encoding: PublicKeyEncoding::X509,
-                data: v.to_der()?,
-            }),
-        }
+    pub fn new(
+        key_type: PublicKeyType,
+        encoding: PublicKeyEncoding,
+        data: Vec<u8>,
+    ) -> Result<Self> {
+        let pkey = PublicKey::parse_pkey(key_type, encoding, &data)?;
+
+        Ok(PublicKey {
+            key_type,
+            encoding,
+            data,
+
+            pkey,
+        })
     }
 
     pub fn keytype(&self) -> PublicKeyType {
         self.key_type
     }
 
-    pub fn get_body(&self) -> Result<(PublicKeyType, PublicKeyBody)> {
-        match self.encoding {
-            PublicKeyEncoding::Crypto => {
-                Ok((self.key_type, PublicKeyBody::Crypto(self.data.clone())))
-            }
-            PublicKeyEncoding::X509 => Ok((
-                self.key_type,
-                PublicKeyBody::X509(X509::from_der(&self.data)?),
-            )),
+    fn parse_pkey(
+        key_type: PublicKeyType,
+        encoding: PublicKeyEncoding,
+        data: &[u8],
+    ) -> Result<PKey<Public>> {
+        match encoding {
+            PublicKeyEncoding::X509 => match key_type {
+                PublicKeyType::SECP256R1 | PublicKeyType::SECP384R1 => {
+                    Ok(PKey::public_key_from_der(data)?)
+                }
+            },
             _ => todo!(),
         }
     }
 
-    pub fn as_pkey(&self) -> Result<PKey<Public>> {
-        PublicKeyBody::try_from(self)?.as_pkey()
+    pub fn pkey(&self) -> &PKeyRef<Public> {
+        &self.pkey
     }
 
     pub fn matches_pkey<T: openssl::pkey::HasPublic>(&self, other: &PKeyRef<T>) -> Result<bool> {
-        let self_pkey = self.as_pkey()?;
+        Ok(self.pkey.public_eq(other))
+    }
+}
 
-        Ok(self_pkey.public_eq(other))
+impl<P> TryFrom<&PKeyRef<P>> for PublicKey
+where
+    P: openssl::pkey::HasPublic,
+{
+    type Error = Error;
+
+    fn try_from(pkey: &PKeyRef<P>) -> Result<Self> {
+        let key = pkey.public_key_to_der()?;
+        let key_type = match pkey.id() {
+            pkey::Id::EC => match pkey.ec_key()?.group().curve_name() {
+                Some(Nid::X9_62_PRIME256V1) => PublicKeyType::SECP256R1,
+                Some(Nid::SECP384R1) => PublicKeyType::SECP384R1,
+                _ => return Err(Error::UnsupportedAlgorithm),
+            },
+            _ => return Err(Error::UnsupportedAlgorithm),
+        };
+        PublicKey::new(key_type, PublicKeyEncoding::X509, key)
+    }
+}
+
+impl<P> TryFrom<&PKey<P>> for PublicKey
+where
+    P: openssl::pkey::HasPublic,
+{
+    type Error = Error;
+
+    fn try_from(pkey: &PKey<P>) -> Result<Self> {
+        PublicKey::try_from(pkey.as_ref())
+    }
+}
+
+impl TryFrom<&X509> for PublicKey {
+    type Error = Error;
+
+    fn try_from(x509: &X509) -> Result<Self> {
+        PublicKey::try_from(x509.as_ref())
+    }
+}
+
+impl TryFrom<&X509Ref> for PublicKey {
+    type Error = Error;
+
+    fn try_from(x509: &X509Ref) -> Result<Self> {
+        PublicKey::try_from(x509.public_key()?.as_ref())
     }
 }
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Public key ({:?}): ", self.key_type)?;
-        let body = match self.get_body() {
-            Err(_) => return Err(std::fmt::Error),
-            Ok(v) => v.1,
-        };
-        body.fmt(f)
-    }
-}
-
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub enum PublicKeyBody {
-    Crypto(Vec<u8>),
-    X509(X509),
-    // TODO
-    //COSEX509(Vec<u8>),
-    // TODO
-    // COSEKEY(COSEKey),
-}
-
-impl Display for PublicKeyBody {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PublicKeyBody::Crypto(v) => write!(f, "crypto: {}", hex::encode(v)),
-            PublicKeyBody::X509(v) => write!(f, "X509 Subject: {:?}", v.subject_name()),
-        }
-    }
-}
-
-impl TryFrom<&PublicKey> for PublicKeyBody {
-    type Error = Error;
-
-    fn try_from(pk: &PublicKey) -> Result<Self> {
-        Ok(pk.get_body()?.1)
-    }
-}
-
-impl TryFrom<PublicKeyBody> for PublicKey {
-    type Error = Error;
-
-    fn try_from(pkb: PublicKeyBody) -> Result<Self> {
-        match &pkb {
-            PublicKeyBody::X509(cert) => {
-                let algo = match cert.public_key()?.ec_key()?.group().curve_name() {
-                    Some(Nid::X9_62_PRIME256V1) => PublicKeyType::SECP256R1,
-                    Some(Nid::SECP384R1) => PublicKeyType::SECP384R1,
-                    other => {
-                        log::error!("Unsupported EC group encountered: {:?}", other);
-                        return Err(Error::UnsupportedAlgorithm);
-                    }
-                };
-
-                PublicKey::new(algo, pkb)
-            }
-            _ => Err(Error::UnsupportedAlgorithm),
-        }
-    }
-}
-
-impl PublicKeyBody {
-    pub fn as_pkey(&self) -> Result<PKey<Public>> {
-        match self {
-            PublicKeyBody::X509(cert) => cert.public_key().map_err(Error::from),
-            _ => todo!(),
-        }
+        write!(f, "Public key ({:?}): {:?}", self.key_type, self.data)
     }
 }
 
@@ -150,7 +173,13 @@ impl X5Chain {
     }
 
     pub fn verify_from_x5bag(&self, bag: &X5Bag) -> Result<&X509> {
-        self.verify(|bag, cert| bag.contains(cert), bag)
+        self.verify(
+            |bag, cert| {
+                log::trace!("Checking for cert {:?} in X5Bag {:?}", cert, bag);
+                bag.contains(cert)
+            },
+            bag,
+        )
     }
 
     pub fn verify_from_digest(&self, digest: &Hash) -> Result<&X509> {
@@ -166,13 +195,21 @@ impl X5Chain {
     }
 
     pub fn insecure_verify_without_root_verification(&self) -> Result<&X509> {
-        self.verify(|_, _| true, &true)
+        self.verify(
+            |_, cert| {
+                log::trace!("Trusting any certificate as root, so trusting {:?}", cert);
+                true
+            },
+            &true,
+        )
     }
 
     pub fn verify<UD, F>(&self, is_trusted_root: F, user_data: &UD) -> Result<&X509>
     where
         F: Fn(&UD, &X509) -> bool,
     {
+        log::trace!("Validating X5Chain {:?}", self);
+
         match self.chain.len() {
             0 => Err(Error::InvalidChain(ChainError::Empty)),
             1 => {
@@ -182,23 +219,25 @@ impl X5Chain {
                     Err(Error::InvalidChain(ChainError::NoTrustedRoot))
                 }
             }
-            _ => {
-                let mut has_trusted_root = false;
-                for certpos in 0..self.chain.len() - 1 {
+            n => {
+                for certpos in 0..n - 1 {
                     let cert = &self.chain[certpos];
                     let issuer = &self.chain[certpos + 1];
+                    log::trace!("Validating that {:?} is signed by {:?}", cert, issuer);
+                    if issuer.issued(cert) != X509VerifyResult::OK {
+                        return Err(Error::InvalidChain(ChainError::NonIssuer(certpos)));
+                    }
                     if !cert.verify(&issuer.public_key().unwrap())? {
                         return Err(Error::InvalidChain(ChainError::InvalidSignedCert(certpos)));
                     }
-                    if !has_trusted_root && is_trusted_root(user_data, issuer) {
-                        has_trusted_root = true;
+                    log::trace!("Checking if {:?} is a trusted root", issuer);
+                    if is_trusted_root(user_data, issuer) {
+                        // We have chained up to a trusted root, so we're all good
+                        log::trace!("Was a trusted root, returning leaf certificate");
+                        return Ok(&self.chain[0]);
                     }
                 }
-                if !has_trusted_root {
-                    return Err(Error::InvalidChain(ChainError::NoTrustedRoot));
-                }
-
-                Ok(&self.chain[self.chain.len() - 1])
+                Err(Error::InvalidChain(ChainError::NoTrustedRoot))
             }
         }
     }

--- a/integration/prepare.sh
+++ b/integration/prepare.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+rm -rf integration/testdata/{keys,ownership_vouchers,rendezvous_registered}/
+mkdir integration/testdata/keys
+openssl ecparam -name prime256v1 -genkey -out integration/testdata/keys/manufacturer_key.der -outform der
+openssl req -x509 -key integration/testdata/keys/manufacturer_key.der -keyform der -out integration/testdata/keys/manufacturer_cert.pem -days 365 -subj "/C=US/O=RHEL for Edge/CN=FIDO Manufacturer"
+openssl ecparam -name prime256v1 -genkey -out integration/testdata/keys/device_ca_key.der -outform der
+openssl req -x509 -key integration/testdata/keys/device_ca_key.der -keyform der -out integration/testdata/keys/device_ca_cert.pem -days 365 -subj "/C=US/O=RHEL for Edge/CN=Device"
+openssl ecparam -name prime256v1 -genkey -out integration/testdata/keys/owner_key.der -outform der
+openssl req -x509 -key integration/testdata/keys/owner_key.der -keyform der -out integration/testdata/keys/owner_cert.pem -days 365 -subj "/C=US/O=RHEL for Edge/CN=Owner"
+openssl ecparam -name prime256v1 -genkey -out integration/testdata/keys/reseller_key.der -outform der
+openssl req -x509 -key integration/testdata/keys/reseller_key.der -keyform der -out integration/testdata/keys/reseller_cert.pem -days 365 -subj "/C=US/O=RHEL for Edge/CN=Reseller"
+mkdir integration/testdata/ownership_vouchers
+mkdir integration/testdata/rendezvous_registered

--- a/owner-onboarding-service/src/main.rs
+++ b/owner-onboarding-service/src/main.rs
@@ -9,16 +9,13 @@ use openssl::{
     ec::{EcGroup, EcKey},
     nid::Nid,
     pkey::{PKey, Private},
-    x509::{X509Builder, X509},
+    x509::X509,
 };
 use serde::Deserialize;
 use warp::Filter;
 
 use fdo_data_formats::{
-    enhanced_types::X5Bag,
-    ownershipvoucher::OwnershipVoucher,
-    publickey::{PublicKey, PublicKeyBody},
-    types::Guid,
+    enhanced_types::X5Bag, ownershipvoucher::OwnershipVoucher, publickey::PublicKey, types::Guid,
 };
 use fdo_store::{Store, StoreDriver};
 
@@ -108,17 +105,8 @@ fn generate_owner2_keys() -> Result<(PKey<Private>, PublicKey)> {
     let owner2_key =
         PKey::from_ec_key(owner2_key).context("ERror converting owner2 key to PKey")?;
 
-    let mut builder = X509Builder::new().context("Error creating X509Builder")?;
-    builder
-        .set_pubkey(&owner2_key)
-        .context("Error setting public key")?;
-    builder
-        .sign(&owner2_key, openssl::hash::MessageDigest::sha384())
-        .context("Error signing certificate")?;
-
-    let cert = builder.build();
-    let cert = PublicKeyBody::X509(cert);
-    let pubkey = PublicKey::try_from(cert).context("Error converting PKB to PK")?;
+    let pubkey =
+        PublicKey::try_from(&owner2_key).context("Error converting ephemeral owner2 key to PK")?;
 
     Ok((owner2_key, pubkey))
 }

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -23,12 +23,12 @@ use serde_cbor::Value as CborValue;
 use serde_yaml::Value;
 
 use fdo_data_formats::{
-    constants::{HashType, PublicKeyType, RendezvousVariable, TransportProtocol},
+    constants::{HashType, RendezvousVariable, TransportProtocol},
     devicecredential::FileDeviceCredential,
     enhanced_types::RendezvousInterpreterSide,
     messages,
     ownershipvoucher::{OwnershipVoucher, OwnershipVoucherHeader},
-    publickey::{PublicKey, PublicKeyBody, X5Chain},
+    publickey::{PublicKey, X5Chain},
     types::{
         COSESign, Guid, HMac, Hash, RendezvousDirective, RendezvousInfo, TO0Data, TO1DataPayload,
         TO2AddressEntry,
@@ -349,8 +349,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
             manufacturer_cert_path
         )
     })?;
-    let manufacturer_cert = PublicKeyBody::X509(manufacturer_cert);
-    let manufacturer_pubkey = PublicKey::new(PublicKeyType::SECP256R1, manufacturer_cert)
+    let manufacturer_pubkey = PublicKey::try_from(&manufacturer_cert)
         .context("Error creating manufacturer public key representation")?;
     let manufacturer_pubkey_hash = Hash::new(
         None,
@@ -620,10 +619,8 @@ fn extend_voucher(matches: &ArgMatches) -> Result<(), Error> {
             new_owner_cert_path
         )
     })?;
-
-    let new_owner_cert = PublicKeyBody::X509(new_owner_cert);
-    let new_owner_pubkey = PublicKey::new(PublicKeyType::SECP256R1, new_owner_cert)
-        .context("Error creating new public key")?;
+    let new_owner_pubkey =
+        PublicKey::try_from(&new_owner_cert).context("Error serializing owner public key")?;
 
     ov.extend(&current_owner_private_key, None, &new_owner_pubkey)
         .context("Error extending ownership voucher")?;

--- a/rendezvous-server/src/handlers_to1.rs
+++ b/rendezvous-server/src/handlers_to1.rs
@@ -131,11 +131,7 @@ pub(super) async fn prove_to_rv(
     };
 
     // Check if token is signed
-    let dev_pkey = dev_pkey
-        .as_pkey()
-        .map_err(Error::from_error::<messages::to1::ProveToRV, _>)?;
-
-    let device_eat = msg.token().get_eat(&dev_pkey).map_err(|e| {
+    let device_eat = msg.token().get_eat(dev_pkey.pkey()).map_err(|e| {
         log::debug!("Error parsing EAToken: {:?}", e);
         Error::new(
             ErrorCode::InvalidMessageError,


### PR DESCRIPTION
When doing the initial implementation of PublicKey, we were expecting
X509 certificate DER data to be passed in, but we should instead be
sending and expecting DER encoded public keys.

During this, we also ensured that the DER data is correct at the moment
a PublicKey is constructed.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>