### PR TITLE
fix: make directory store driver replace slashes

### DIFF
--- a/integration-tests/templates/manufacturing-service.yml.j2
+++ b/integration-tests/templates/manufacturing-service.yml.j2
@@ -1,5 +1,6 @@
 ---
-session_store_driver: InMemory
+session_store_driver: Directory
+session_store_config: sessions/
 ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: ownership_vouchers/
 bind: {{ bind }}

--- a/integration-tests/templates/owner-onboarding-service.yml.j2
+++ b/integration-tests/templates/owner-onboarding-service.yml.j2
@@ -1,5 +1,6 @@
 ---
-session_store_driver: InMemory
+session_store_driver: Directory
+session_store_config: sessions/
 ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: ownership_vouchers/
 trusted_device_keys_path: {{ keys_path }}/device_ca_cert.pem

--- a/integration-tests/templates/rendezvous-service.yml.j2
+++ b/integration-tests/templates/rendezvous-service.yml.j2
@@ -1,7 +1,8 @@
 ---
 storage_driver: Directory
 storage_config: rendezvous_registered/
-session_store_driver: InMemory
+session_store_driver: Directory
+session_store_config: sessions/
 trusted_manufacturer_keys_path: {{ keys_path }}/manufacturer_cert.pem
 trusted_device_keys_path: {{ keys_path }}/device_ca_cert.pem
 bind: {{ bind }}

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -18,6 +18,7 @@ async fn test_to() -> Result<()> {
             |cfg| {
                 cfg.prepare_config_file(None, |_| Ok(()))?;
                 cfg.create_empty_storage_folder("rendezvous_registered")?;
+                cfg.create_empty_storage_folder("sessions")?;
                 Ok(())
             },
             |_| Ok(()),
@@ -29,6 +30,7 @@ async fn test_to() -> Result<()> {
             |cfg| {
                 cfg.prepare_config_file(None, |_| Ok(()))?;
                 cfg.create_empty_storage_folder("ownership_vouchers")?;
+                cfg.create_empty_storage_folder("sessions")?;
                 Ok(())
             },
             |_| Ok(()),

--- a/store/src/directory.rs
+++ b/store/src/directory.rs
@@ -57,7 +57,7 @@ where
     K: std::string::ToString,
 {
     fn get_path(&self, key: &K) -> PathBuf {
-        self.directory.join(key.to_string())
+        self.directory.join(key.to_string().replace("/", "_slash_"))
     }
 }
 


### PR DESCRIPTION
Session IDs have a reasonable chance to have forward slashes in them,
since they're base64-encoded.
This patch makes the Directory driver replace the forward slashes with
"_slash_", to make sure that we can store those files.

Fixes: #53
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>