### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore: "
     reviewers:
     - "fedora-iot/fdo-rs-maintainers"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+        with:
+          failOnWarnings: true


### PR DESCRIPTION
This adds CI to enforce Conventional Commits[1] style commit messages.
If we make sure that further commit messages follow that, we can then
use a tool like git-cliff[2] to automatically generate changelogs.

[1]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[2]: https://github.com/orhun/git-cliff