### PR TITLE
fix: bring PublicKey back to certificates

### DIFF
--- a/data-formats/src/constants.rs
+++ b/data-formats/src/constants.rs
@@ -61,27 +61,30 @@ impl TryFrom<MessageDigest> for HashType {
     }
 }
 
+const RS256: i16 = -257;
+const RS384: i16 = -258;
+
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, Eq, PartialEq)]
-#[repr(i8)]
+#[repr(i16)]
 #[non_exhaustive]
 pub enum DeviceSigType {
-    StSECP256R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES256 as i8),
-    StSECP384R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES384 as i8),
-    // StRSA2048 = RS256,
-    // StRSA3072 = RS384,
+    StSECP256R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES256 as i16),
+    StSECP384R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES384 as i16),
+    StRSA2048 = RS256,
+    StRSA3072 = RS384,
     StEPID10 = 90,
     StEPID11 = 91,
     StEPID20 = 92,
 }
 
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
-#[repr(i8)]
+#[repr(i16)]
 #[non_exhaustive]
 pub enum PublicKeyType {
-    // Rsa2048RESTR = RS256,
-    // Rsa = RS384,
-    SECP256R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES256 as i8),
-    SECP384R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES384 as i8),
+    Rsa2048RESTR = RS256,
+    Rsa = RS384,
+    SECP256R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES256 as i16),
+    SECP384R1 = (aws_nitro_enclaves_cose::sign::SignatureAlgorithm::ES384 as i16),
 }
 
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]

--- a/data-formats/src/messages/diun.rs
+++ b/data-formats/src/messages/diun.rs
@@ -4,7 +4,6 @@ use serde_tuple::Serialize_tuple;
 use super::{ClientMessage, EncryptionRequirement, Message, ServerMessage};
 use crate::{
     constants::{KeyStorageType, MessageType, MfgStringType, PublicKeyType},
-    publickey::PublicKey,
     types::{COSESign, CipherSuite, KexSuite, Nonce},
 };
 
@@ -184,19 +183,19 @@ impl ServerMessage for ProvideKeyParameters {}
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct ProvideKey {
-    public_key: PublicKey,
+    public_key: Vec<u8>, // Key in DER-encoded SubjectPublicKeyInfo format
     public_key_storage: KeyStorageType,
 }
 
 impl ProvideKey {
-    pub fn new(public_key: PublicKey, public_key_storage: KeyStorageType) -> Self {
+    pub fn new(public_key: Vec<u8>, public_key_storage: KeyStorageType) -> Self {
         ProvideKey {
             public_key,
             public_key_storage,
         }
     }
 
-    pub fn public_key(&self) -> &PublicKey {
+    pub fn public_key(&self) -> &[u8] {
         &self.public_key
     }
 

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -351,7 +351,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
             manufacturer_cert_path
         )
     })?;
-    let manufacturer_pubkey = PublicKey::try_from(&manufacturer_cert)
+    let manufacturer_pubkey = PublicKey::try_from(manufacturer_cert)
         .context("Error creating manufacturer public key representation")?;
     let manufacturer_pubkey_hash = Hash::new(
         None,
@@ -413,7 +413,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
     // Construct device certificate chain
     let mut device_cert_chain = device_cert_ca_chain;
     device_cert_chain.insert(0, device_cert);
-    let device_cert_chain = X5Chain::new(device_cert_chain);
+    let device_cert_chain = X5Chain::new(device_cert_chain).context("Error creating X5Chain")?;
     let device_cert_chain_hash = device_cert_chain
         .hash(HashType::Sha384)
         .context("Error computing digest over device certificate chain")?;
@@ -616,7 +616,7 @@ fn extend_voucher(matches: &ArgMatches) -> Result<(), Error> {
         )
     })?;
     let new_owner_pubkey =
-        PublicKey::try_from(&new_owner_cert).context("Error serializing owner public key")?;
+        PublicKey::try_from(new_owner_cert).context("Error serializing owner public key")?;
 
     ov.extend(&current_owner_private_key, None, &new_owner_pubkey)
         .context("Error extending ownership voucher")?;

--- a/rendezvous-server/src/handlers_to0.rs
+++ b/rendezvous-server/src/handlers_to0.rs
@@ -177,6 +177,7 @@ pub(super) async fn ownersign(
             .into());
         }
         Ok(v) => v
+            .clone()
             .try_into()
             .map_err(Error::from_error::<messages::to0::OwnerSign, _>)?,
     };


### PR DESCRIPTION
In PR #48, we changed the PublicKey structure to DER encoded public
keys, because that's how the specification reads.
Unfortunately, that is not the way it was intended: intended was an
actual DER-encoded X509 certificate (X509), or an x5chain (COSEX509).
This will be clarified in an upcoming erratum to the specification.
This patch brings it back to the correct structures.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>