### PR TITLE
Bump openssl dependency for manufacturing-client

### DIFF
--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 anyhow = "1"
 hex = "0.4"
 log = "0.4"
-openssl = "0.10"
+openssl = "0.10.36"
 serde_cbor = "0.11"
 tokio = { version = "1", features = ["full"] }
 sys-info = "0.8"


### PR DESCRIPTION
We use the openssl PKey::raw_private_key function, as used for hmacs.
That got added in 0.10.36, so actually bump the version dependency.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>