### PR TITLE
fix: add versions of internal dependencies

### DIFF
--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -15,5 +15,5 @@ sys-info = "0.9"
 passwd = "0.0.1"
 rand = "0.8.4"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["client"] }

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-store = { path = "../store" }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-store = { path = "../store", version = "0.1.0" }
 aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats" }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
 
 libc = "0.2"
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -16,5 +16,5 @@ sys-info = "0.9"
 passwd = "0.0.1"
 rand = "0.8.4"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["client"] }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -17,7 +17,7 @@ warp = "0.3"
 log = "0.4"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["server"] }
-fdo-store = { path = "../store", features = ["directory"] }
-fdo-util = { path = "../util" }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.1.0", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.1.0" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -17,7 +17,7 @@ warp = "0.3"
 serde_cbor = "0.11"
 log = "0.4"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["server"] }
-fdo-store = { path = "../store", features = ["directory"] }
-fdo-util = { path = "../util"}
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.1.0", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.1.0" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -15,8 +15,8 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["client"] }
 
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -16,7 +16,7 @@ openssl = "0.10"
 warp = "0.3"
 log = "0.4"
 
-fdo-data-formats = { path = "../data-formats" }
-fdo-http-wrapper = { path = "../http-wrapper", features = ["server"] }
-fdo-store = { path = "../store" }
-fdo-util = { path = "../util" }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.1.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.1.0" }
+fdo-util = { path = "../util", version = "0.1.0" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats" }
+fdo-data-formats = { path = "../data-formats", version = "0.1.0" }
 
 config = "0.11"
 futures = "0.3"


### PR DESCRIPTION
The versions need to be specified for every crate in order to be
publishable to crates.io, until [1] gets implemented.

[1]: https://github.com/rust-lang/rfcs/blob/master/text/2906-cargo-workspace-deduplicate.md

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>