### PR TITLE
chore: ignore test vouchers with gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,3 @@
+[allowlist]
+  description = "Allowlist"
+  paths = ['''integration-tests\/vouchers\/([a-z0-9_]*)''']


### PR DESCRIPTION
This makes it so our ownership vouchers aren't alerted for by gitleaks
when we add the private keys.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>