### PR TITLE
fix: adding golang to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-redhat.sh")" -- "true" "vscode" "1000" "1000" "true"
 
 RUN dnf install -y \
-    sudo git cargo rust rust-src openssl-devel clippy rustfmt \
+    sudo git cargo rust rust-src openssl-devel clippy rustfmt golang \
     && dnf clean all
 
 USER vscode


### PR DESCRIPTION
Adding Golang to the dev container so Go wrapper tests can work.