### PR TITLE
fix: use correct lengths for random sizes

### DIFF
--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -1190,8 +1190,8 @@ impl<'de> Deserialize<'de> for KexSuite {
 impl KexSuite {
     fn get_ecdh_random_size(&self) -> usize {
         match self {
-            KexSuite::Ecdh256 => 128,
-            KexSuite::Ecdh384 => 384,
+            KexSuite::Ecdh256 => 16,
+            KexSuite::Ecdh384 => 48,
             _ => panic!("Invalid get_ecdh_random_size call"),
         }
     }


### PR DESCRIPTION
The random size from the spec is in bits, and we specify it in bytes.
Make sure that we generate and expect the correct number of random
bytes.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>