### PR TITLE
fix: add owner public key

### DIFF
--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -5,6 +5,7 @@ ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: ownership_vouchers/
 trusted_device_keys_path: {{ keys_path }}/device_ca_cert.pem
 owner_private_key_path: {{ keys_path }}/owner_key.der
+owner_public_key_path: {{ keys_path }}/owner_cert.pem
 bind: {{ bind }}
 service_info:
   rhsm_organization_id: 6454383

--- a/owner-onboarding-server/src/handlers.rs
+++ b/owner-onboarding-server/src/handlers.rs
@@ -103,6 +103,9 @@ pub(super) async fn hello_device(
     res_header
         .insert(HeaderKeys::CUPHNonce, &nonce6)
         .map_err(Error::from_error::<messages::to2::HelloDevice, _>)?;
+    res_header
+        .insert(HeaderKeys::CUPHOwnerPubKey, &user_data.owner_pubkey)
+        .map_err(Error::from_error::<messages::to2::HelloDevice, _>)?;
 
     let res = COSESign::new(&res_payload, Some(res_header), &user_data.owner_key)
         .map_err(Error::from_error::<messages::to2::HelloDevice, _>)?;

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -38,6 +38,7 @@ struct OwnerServiceUD {
 
     // Our keys
     owner_key: PKey<Private>,
+    owner_pubkey: PublicKey,
 
     // The new Owner2Key, randomly generated, but not stored
     owner2_key: PKey<Private>,
@@ -64,6 +65,7 @@ struct Settings {
 
     // Our private owner key
     owner_private_key_path: String,
+    owner_public_key_path: String,
 
     // Bind information
     bind: String,
@@ -174,6 +176,16 @@ async fn main() -> Result<()> {
             &settings.owner_private_key_path
         )
     })?;
+    let owner_pubkey = {
+        let contents = std::fs::read(&settings.owner_public_key_path).with_context(|| {
+            format!(
+                "Error reading owner public key from {}",
+                &settings.owner_public_key_path
+            )
+        })?;
+        PublicKey::try_from(X509::from_pem(&contents).context("Error parsing owner public key")?)
+            .context("Error converting owner public key to PK")?
+    };
 
     // Initialize stores
     let ownership_voucher_store = settings
@@ -201,6 +213,7 @@ async fn main() -> Result<()> {
 
         // Private owner key
         owner_key,
+        owner_pubkey,
 
         // Ephemeral owner2 key
         owner2_key,


### PR DESCRIPTION
The CUPHOwnerPubKey is non-optional, so we make sure that we send the
owners public key.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>