### PR TITLE
fix: use the correct nonce key for nonce7

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -370,7 +370,7 @@ async fn perform_to2(
     .context("Error building provedevice EAT")?;
     let mut prove_device_eat_unprotected = COSEHeaderMap::new();
     prove_device_eat_unprotected
-        .insert(HeaderKeys::CUPHNonce, &nonce7)
+        .insert(HeaderKeys::EUPHNonce, &nonce7)
         .context("Error adding nonce7 to unprotected")?;
     let signer = devcred.get_signer().context("Error getting Cose signer")?;
     let prove_device_token = COSESign::from_eat(

--- a/data-formats/src/constants.rs
+++ b/data-formats/src/constants.rs
@@ -129,6 +129,7 @@ pub enum HeaderKeys {
 
     CUPHNonce = -17760701,       // IANA Pending
     CUPHOwnerPubKey = -17760702, // IANA Pending
+    EUPHNonce = -17760709,       // IANA Pending
 
     EatFDO = -17760707,
 }

--- a/owner-onboarding-server/src/handlers.rs
+++ b/owner-onboarding-server/src/handlers.rs
@@ -258,7 +258,7 @@ pub(super) async fn prove_device(
     // Get device EAT
     let token = msg.into_token();
     let nonce7: Nonce = match token
-        .get_unprotected_value(HeaderKeys::CUPHNonce)
+        .get_unprotected_value(HeaderKeys::EUPHNonce)
         .map_err(Error::from_error::<messages::to2::ProveDevice, _>)?
     {
         Some(n) => n,


### PR DESCRIPTION
This was updated from an earlier draft, so update to use the correct key
for the nonce in the TO2 protocol.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>