### PR TITLE
fix: make ServiceInfo a Vec<Vec<KV>>

### DIFF
--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -665,11 +665,11 @@ impl TO2ProveDevicePayload {
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct ServiceInfo(Vec<(String, CborSimpleType)>);
+pub struct ServiceInfo(Vec<Vec<(String, CborSimpleType)>>);
 
 impl ServiceInfo {
     pub fn new() -> Self {
-        ServiceInfo(Vec::new())
+        ServiceInfo(vec![Vec::new()])
     }
 
     pub fn add<T>(&mut self, module: &str, key: &str, value: &T) -> Result<(), Error>
@@ -677,7 +677,7 @@ impl ServiceInfo {
         T: serde::Serialize,
     {
         let value = serde_cbor::value::to_value(&value)?;
-        self.0.push((format!("{}:{}", module, key), value));
+        self.0[0].push((format!("{}:{}", module, key), value));
         Ok(())
     }
 
@@ -698,12 +698,17 @@ impl ServiceInfo {
     }
 
     pub fn iter(&self) -> ServiceInfoIter {
-        ServiceInfoIter { info: self, pos: 0 }
+        ServiceInfoIter {
+            info: self,
+            inner_pos: 0,
+            pos: 0,
+        }
     }
 
     pub fn values(&self) -> Result<Vec<(String, String, CborSimpleType)>, Error> {
         self.0
             .iter()
+            .flatten()
             .map(|(k, v)| match k.find(':') {
                 None => Err(Error::InconsistentValue(
                     "ServiceInfo key missing module separation",
@@ -720,6 +725,7 @@ impl ServiceInfo {
 #[derive(Debug)]
 pub struct ServiceInfoIter<'a> {
     info: &'a ServiceInfo,
+    inner_pos: usize,
     pos: usize,
 }
 
@@ -727,10 +733,14 @@ impl Iterator for ServiceInfoIter<'_> {
     type Item = (String, String, CborSimpleType);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos >= self.info.0.len() {
+        if self.inner_pos >= self.info.0.len() {
             return None;
         }
-        let (module_key, val) = &self.info.0[self.pos];
+        if self.pos >= self.info.0[self.inner_pos].len() {
+            self.inner_pos += 1;
+            return self.next();
+        }
+        let (module_key, val) = &self.info.0[self.inner_pos][self.pos];
         self.pos += 1;
 
         // When it's stable, use str.split_once


### PR DESCRIPTION
The ServiceInfo is a nested Vec, instead of just one Vec of KV pairs.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>