### PR TITLE
feat: use ciborium for serializing

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ciborium = "0.1.0"
 hex = "0.4"
 openssl = "0.10.34"
 openssl-kdf = "0.1"

--- a/data-formats/src/errors.rs
+++ b/data-formats/src/errors.rs
@@ -20,7 +20,9 @@ pub enum Error {
     #[error("Cryptographic error stack: {0}")]
     CryptoStack(#[from] openssl::error::ErrorStack),
     #[error("Serialization error: {0}")]
-    Serialization(#[from] serde_cbor::Error),
+    SerdeCborError(#[from] serde_cbor::Error),
+    #[error("Serialization error (ciborium): {0}")]
+    CiboriumSerError(#[from] ciborium::ser::Error<std::io::Error>),
     #[error("COSE error: {0}")]
     Cose(#[from] aws_nitro_enclaves_cose::error::CoseError),
     #[error("Invalid hash value")]

--- a/data-formats/src/serializable.rs
+++ b/data-formats/src/serializable.rs
@@ -43,13 +43,15 @@ where
     }
 
     fn serialize_data(&self) -> Result<Vec<u8>, Error> {
-        serde_cbor::to_vec(self).map_err(Error::from)
+        let mut output = Vec::new();
+        ciborium::ser::into_writer(self, &mut output)?;
+        Ok(output)
     }
 
     fn serialize_to_writer<W>(&self, mut writer: W) -> Result<(), Error>
     where
         W: std::io::Write,
     {
-        serde_cbor::to_writer(&mut writer, self).map_err(Error::from)
+        ciborium::ser::into_writer(self, &mut writer).map_err(Error::from)
     }
 }


### PR DESCRIPTION
The specification does not require CBOR canonical encoding, but some
other implementations do, due to the amount of nested data structures
that need to get hashes.
In order to make sure we generate contents they can correctly hash, this
changes us to use ciborium for serializing, since that generates
canonical CBOR (for the parts we care about).
This means we now have two CBOR libraries, and we might want to move to
ciborium fully further down the line, but at this moment using it for
just serializing is the easy-fix that gets us compatible with other
implementations.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>