### PR TITLE
ci: fix permissions on labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,10 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The labeler workflow needs permissions to update PRs in order to apply
labels.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>