### PR TITLE
feat: cancel to2 if to1d was invalid

### DIFF
--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -1777,6 +1777,14 @@ impl COSESign {
         Self::new_from_inner(inner)
     }
 
+    pub fn verify(&self, sign_key: &dyn SigningPublicKey) -> Result<(), Error> {
+        if self.cached_inner.verify_signature(sign_key)? {
+            Ok(())
+        } else {
+            Err(Error::InconsistentValue("Signature verification failed"))
+        }
+    }
+
     pub fn from_eat<ES>(
         eat: EATokenPayload<ES>,
         unprotected: Option<COSEHeaderMap>,


### PR DESCRIPTION
If the to1d we received as part of the TO1 protocol is invalid, we need
to stop the TO2 that we were performing with that same to1d document.

Fixes: #81
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>