### PR TITLE
ci: require extra review on stability impact

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
 - name: fido-device-onboard-rs
+  batch_size: 5
   conditions:
     - base=main
     - "#approved-reviews-by>=1"
@@ -9,6 +10,18 @@ pull_request_rules:
     conditions:
     - base=main
     - "#approved-reviews-by>=1"
+    - "label!=possible stability impact"
+    actions:
+      queue:
+        name: fido-device-onboard-rs
+        method: merge
+        rebase_fallback: none
+
+  - name: Automatic merge on approval (stability impact)
+    conditions:
+    - base=main
+    - "#approved-reviews-by>=2"
+    - "label=possible stability impact"
     actions:
       queue:
         name: fido-device-onboard-rs


### PR DESCRIPTION
For PRs that have a possible stability impact, we want to enforce extra
reviews.
Do this by requiring a second review for these PRs.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>