### PR TITLE
fix(spec): use forgesetup

### DIFF
--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -34,7 +34,7 @@ BuildRequires: openssl-devel
 %{summary}.
 
 %prep
-%autosetup -n %{name}-rs-%{commit} -p1
+%forgesetup
 %if 0%{?rhel} && !0%{?eln}
 %cargo_prep -V 1
 %else


### PR DESCRIPTION
Hopefully the last PR around the spec file @nullr0ute :angel: 

This allows us to keep building with make rpm just fine and just change
the vendor tar gz downstream variable to version instead of commit.

Signed-off-by: Antonio Murdaca <runcom@linux.com>