### PR TITLE
feat: switch back to openssl-kdf

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -27,5 +27,8 @@ pem = "1.0"
 http = "0.2"
 hyper = "0.14"
 
+# TODO: Move away from {allow,force}_custom when UseL and R are implemented for ossl11
+openssl-kdf = { version = "0.3", features = ["allow_custom", "force_custom"] }
+
 [dev-dependencies]
 maplit = "1.0"

--- a/data-formats/src/errors.rs
+++ b/data-formats/src/errors.rs
@@ -19,6 +19,8 @@ pub enum ChainError {
 pub enum Error {
     #[error("Cryptographic error stack: {0}")]
     CryptoStack(#[from] openssl::error::ErrorStack),
+    #[error("Key derivation error: {0:?}")]
+    Kdf(#[from] openssl_kdf::KdfError),
     #[error("Serialization error: {0}")]
     SerdeCborError(#[from] serde_cbor::Error),
     #[error("Serialization error (ciborium): {0}")]


### PR DESCRIPTION
openssl-kdf has added the required functionality (custom r and ability
to skip L).
This allows us to use that implementation.
For now, we are using its custom implementation, until the required
patch is backported to OSSL1.1 and OSSL3.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>