### PR TITLE
fix(spec): build with version if commit undefined

### DIFF
--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -15,7 +15,11 @@ License:        BSD 3
 URL:            %{forgeurl}
 Source:         %{forgesource}
 %if 0%{?rhel} && !0%{?eln}
+%if "%{?commit}" != ""
 Source1:        %{name}-rs-%{commit}-vendor.tar.gz
+%else
+Source1:        %{name}-rs-%{version}-vendor.tar.gz
+%endif
 %endif
 
 ExclusiveArch:  %{rust_arches}


### PR DESCRIPTION
This allows us to have the same upstream and downstream spec file.
commit is needed for mainly dev and snapshots, version is what we really
use once we build downstream in Fedora/RHEL. `commit` is either defined in dev using forgemeta and Makefile or not set downstream (cause there we usually ship tagged versions)

Signed-off-by: Antonio Murdaca <runcom@linux.com>