### PR TITLE
feat: add non-interoperable KDF

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -460,6 +460,10 @@ fn sleep_between_retries(rv_entry_delay: u32) {
 async fn main() -> Result<()> {
     fdo_http_wrapper::init_logging();
 
+    if !fdo_data_formats::INTEROPERABLE_KDF && std::env::var("ALLOW_NONINTEROPABLE_KDF").is_err() {
+        bail!("Provide environment ALLOW_NONINTEROPERABLE_KDF=1 to enable interoperable KDF");
+    }
+
     let marker_file = marker_file_location();
     if marker_file.exists() {
         log::info!(

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -27,8 +27,14 @@ pem = "1.0"
 http = "0.2"
 hyper = "0.14"
 
-# TODO: Move away from {allow,force}_custom when UseL and R are implemented for ossl11
-openssl-kdf = { version = "0.3", features = ["allow_custom", "force_custom"] }
+openssl-kdf = { version = "0.4", features = ["allow_custom"] }
+
+[features]
+# Whether to use a non-interoperable KDF.
+use_noninteroperable_kdf = []
+
+[build-dependencies]
+openssl-kdf = { version = "0.4.1", features = ["allow_custom"] }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/data-formats/build.rs
+++ b/data-formats/build.rs
@@ -1,0 +1,24 @@
+use openssl_kdf::{supports_args, KdfArgument};
+
+#[allow(clippy::panic)]
+fn main() {
+    if std::env::var("CARGO_FEATURE_USE_NONINTEROPERABLE_KDF").is_err() {
+        let test_args = &[
+            &KdfArgument::Salt(&[]),
+            &KdfArgument::KbInfo(&[]),
+            &KdfArgument::Key(&[]),
+            &KdfArgument::UseL(false),
+            &KdfArgument::R(8),
+        ];
+
+        if !supports_args(test_args) {
+            panic!(
+                "\n\
+				Current KDF implementation does not support the interoperable parameters.\n\
+				If you still want to build, you can enable the non-interoperable KDF, but be aware that \
+				that implementation does not interoperate with FDO-spec-compliant implementations.\n\
+				"
+            );
+        }
+    }
+}

--- a/data-formats/src/lib.rs
+++ b/data-formats/src/lib.rs
@@ -25,3 +25,8 @@ pub mod cborparser;
 mod serializable;
 pub use serializable::DeserializableMany;
 pub use serializable::Serializable;
+
+#[cfg(feature = "use_noninteroperable_kdf")]
+pub const INTEROPERABLE_KDF: bool = false;
+#[cfg(not(feature = "use_noninteroperable_kdf"))]
+pub const INTEROPERABLE_KDF: bool = true;

--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -1099,13 +1099,18 @@ impl KeyExchange {
         salt.extend_from_slice(&context_rand);
         salt.extend_from_slice(&(cipher.required_keylen() as u16).to_be_bytes());
 
+        #[cfg(not(feature = "use_noninteroperable_kdf"))]
+        log::warn!("Using non-interoperable key derivation");
+
         let kdf_args = [
             &KdfArgument::KbMode(KdfKbMode::Counter),
             &KdfArgument::Mac(KdfMacType::Hmac(cipher.kdf_digest())),
             &KdfArgument::Salt(KEY_DERIVE_LABEL),
             &KdfArgument::KbInfo(&salt),
             &KdfArgument::Key(&shared_secret),
+            #[cfg(not(feature = "use_noninteroperable_kdf"))]
             &KdfArgument::UseL(false),
+            #[cfg(not(feature = "use_noninteroperable_kdf"))]
             &KdfArgument::R(8),
         ];
         let key_out = perform_kdf(KdfType::KeyBased, &kdf_args, cipher.required_keylen())?;

--- a/http-wrapper/src/client.rs
+++ b/http-wrapper/src/client.rs
@@ -124,6 +124,10 @@ impl ServiceClient {
             req = req.header("Authorization", authorization_token);
         }
 
+        if !fdo_data_formats::INTEROPERABLE_KDF {
+            req = req.header("X-Non-Interoperable-KDF", "true");
+        }
+
         if let Some(new_keys) = new_keys {
             self.encryption_keys = new_keys;
         }

--- a/http-wrapper/src/server.rs
+++ b/http-wrapper/src/server.rs
@@ -306,6 +306,9 @@ where
             builder = builder.header("Authorization", token);
         }
     }
+    if !fdo_data_formats::INTEROPERABLE_KDF {
+        builder = builder.header("X-Non-Interoperable-KDF", "true");
+    }
 
     builder.body(val.into()).unwrap()
 }

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -26,7 +26,10 @@ async fn test_to() -> Result<()> {
                 cfg.prepare_config_file(Some("owner-addresses.yml"), |_| Ok(()))?;
                 Ok(cfg.prepare_config_file(None, |_| Ok(()))?)
             },
-            |_| Ok(()),
+            |cmd| {
+                cmd.env("ALLOW_NONINTEROPABLE_KDF", &"1");
+                Ok(())
+            },
         )
         .context("Error creating owner server")?;
     ctx.wait_until_servers_ready()
@@ -163,7 +166,8 @@ async fn test_to() -> Result<()> {
                     .env(
                         "DEVICE_ONBOARDING_EXECUTED_MARKER_FILE_PATH",
                         &marker_file_path.to_str().unwrap(),
-                    );
+                    )
+                    .env("ALLOW_NONINTEROPABLE_KDF", &"1");
                 Ok(())
             },
             Duration::from_secs(5),

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -292,6 +292,10 @@ fn generate_owner2_keys() -> Result<(PKey<Private>, PublicKey)> {
 async fn main() -> Result<()> {
     fdo_http_wrapper::init_logging();
 
+    if !fdo_data_formats::INTEROPERABLE_KDF && std::env::var("ALLOW_NONINTEROPABLE_KDF").is_err() {
+        bail!("Provide environment ALLOW_NONINTEROPERABLE_KDF=1 to enable interoperable KDF");
+    }
+
     let settings: Settings = settings_for("owner-onboarding-server")?
         .try_into()
         .context("Error parsing configuration")?;


### PR DESCRIPTION
This adds the ability to add a non-interoperable KDF implementation.
This should never be used in production environments, as it will be not
interoperable with other implementations, or this implementation with
the interoperable KDF.

When the non-interoperable KDF is enabled, the client and server will
send a header to indicate this, so it becomes possible for the other
side to dynamically fall back to the non-interoperable KDF when needed.
This is work for a future patch, but this ensures that such a patch will
have the required information.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>