### PR TITLE
Implement file and command serviceinfo modules

### DIFF
--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
+serde_bytes = "0.11"
 passwd = "0.0.1"
 rand = "0.8.4"
 nix = "0.23.0"

--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -1,13 +1,19 @@
-use std::path::Path;
 use std::process::Command;
+use std::{
+    collections::HashSet,
+    fs::{File, Permissions},
+    io::Write,
+    path::Path,
+};
 use std::{env, fs};
 use std::{os::unix::fs::PermissionsExt, path::PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 
 use fdo_data_formats::{
+    constants::HashType,
     messages::to2::{DeviceServiceInfo, OwnerServiceInfo},
-    types::{CborSimpleTypeExt, ServiceInfo},
+    types::{CborSimpleTypeExt, Hash, ServiceInfo},
 };
 use fdo_http_wrapper::client::{RequestResult, ServiceClient};
 
@@ -18,6 +24,7 @@ fn find_available_modules() -> Result<Vec<String>> {
         // These modules are always here
         "devmod".to_string(),
         "sshkey".to_string(),
+        "binaryfile".to_string(),
     ];
 
     // See if we add RHSM
@@ -113,8 +120,61 @@ fn perform_rhsm(organization_id: &str, activation_key: &str, perform_insights: b
     Ok(())
 }
 
+fn deploy_binaryfile(file: BinaryFileInProgress) -> Result<()> {
+    let path = file.path.as_ref().unwrap();
+
+    let path = if let Ok(val) = env::var("BINARYFILE_PATH_PREFIX") {
+        PathBuf::from(&val).join(path)
+    } else {
+        PathBuf::from(path)
+    };
+
+    if !path.is_absolute() {
+        bail!("Binaryfile path must be absolute");
+    }
+
+    let contents = file.contents.as_ref().unwrap();
+    let mode = file.mode.unwrap_or(0o600);
+
+    log::info!(
+        "Creating file {:?} with {} bytes (mode {:?})",
+        path,
+        file.length.unwrap(),
+        mode
+    );
+
+    let mut file = File::create(path).context("Error creating file")?;
+    file.write_all(contents).context("Error writing file")?;
+    file.set_permissions(Permissions::from_mode(mode))
+        .context("Error setting file permissions")?;
+    file.sync_all().context("Error syncing file")?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct BinaryFileInProgress {
+    path: Option<String>,
+    length: Option<u64>,
+    contents: Option<Vec<u8>>,
+    mode: Option<u32>,
+    digest: Option<Hash>,
+}
+
+impl BinaryFileInProgress {
+    fn new() -> Self {
+        BinaryFileInProgress {
+            path: None,
+            length: None,
+            contents: None,
+            mode: None,
+            digest: None,
+        }
+    }
+}
+
 async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
-    let mut active_modules: Vec<String> = Vec::new();
+    let mut active_modules: HashSet<String> = HashSet::new();
 
     let mut sshkey_user: Option<String> = None;
     let mut sshkey_key: Option<String> = None;
@@ -123,17 +183,24 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
     let mut rhsm_activation_key: Option<String> = None;
     let mut rhsm_perform_insights: Option<bool> = None;
 
+    let mut binary_file_in_progress = BinaryFileInProgress::new();
+
     for (module, key, value) in si_in.iter() {
         log::trace!("Got module {}, command {}, value {:?}", module, key, value);
         if key == "active" {
             let value = value.as_bool().context("Error parsing active value")?;
             if value {
                 log::trace!("Activating module {}", module);
-                active_modules.push(module.to_string());
+                active_modules.insert(module.to_string());
             } else {
                 log::trace!("Deactivating module {}", module);
+                active_modules.remove(&module);
             }
             continue;
+        }
+        if !active_modules.contains(&module) {
+            log::trace!("Skipping non-activated module {}", module);
+            bail!("Non-activated module {} got request", module);
         }
         if module == "sshkey" {
             let value = value.as_str().context("Error parsing sshkey value")?;
@@ -159,11 +226,105 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
                     .with_context(|| format!("Error parsing rhsm {} value", key))?;
                 rhsm_perform_insights = Some(value);
             }
+        } else if module == "binaryfile" {
+            if key == "name" {
+                if binary_file_in_progress.path.is_some() {
+                    bail!(
+                        "Got binaryfile path {:?} after path {:?}",
+                        value,
+                        binary_file_in_progress.path
+                    );
+                }
+                binary_file_in_progress.path = Some(
+                    value
+                        .as_str()
+                        .context("Error parsing binaryfile name")?
+                        .to_string(),
+                );
+            } else if key == "length" {
+                if binary_file_in_progress.length.is_some() {
+                    bail!(
+                        "Got binaryfile length {:?} after length {:?}",
+                        value,
+                        binary_file_in_progress.length
+                    );
+                }
+                binary_file_in_progress.length =
+                    Some(value.as_u64().context("Error parsing binaryfile length")?);
+                binary_file_in_progress.contents = Some(Vec::with_capacity(
+                    binary_file_in_progress.length.unwrap() as usize,
+                ));
+            } else if key.starts_with("data") {
+                if binary_file_in_progress.contents.is_none() {
+                    bail!("Got binaryfile data before length {:?}", value);
+                }
+                binary_file_in_progress
+                    .contents
+                    .as_mut()
+                    .unwrap()
+                    .extend_from_slice(value.as_bytes().context("Error parsing binaryfile data")?);
+            } else if key == "mode" {
+                if binary_file_in_progress.mode.is_some() {
+                    bail!(
+                        "Got binaryfile mode {:?} after mode {:?}",
+                        value,
+                        binary_file_in_progress.mode
+                    );
+                }
+                binary_file_in_progress.mode =
+                    Some(value.as_u32().context("Error parsing binaryfile mode")?);
+            } else if key.starts_with("sha-") {
+                let sha_type = key.split('-').nth(1).unwrap();
+                let sha_value = value
+                    .as_bytes()
+                    .with_context(|| format!("Error parsing binaryfile sha-{} value", sha_type))?;
+                let hasher = match sha_type {
+                    "256" => HashType::Sha256,
+                    "384" => HashType::Sha384,
+                    _ => {
+                        bail!("Unknown sha-{}", sha_type);
+                    }
+                };
+                binary_file_in_progress.digest =
+                    Some(Hash::from_digest(hasher, sha_value.to_vec())?);
+
+                // We got the full file, check it and add it to the files to get deployed
+                if binary_file_in_progress.path.is_none() {
+                    bail!("Got binaryfile sha-{} before name", sha_type);
+                }
+                if binary_file_in_progress.length.is_none() {
+                    bail!("Got binaryfile sha-{} before length", sha_type);
+                }
+                let read_bytes = binary_file_in_progress.contents.as_ref().unwrap().len();
+                if read_bytes != binary_file_in_progress.length.unwrap() as usize {
+                    bail!(
+                        "Got binaryfile (path {}) with length {} but only {} bytes of data",
+                        binary_file_in_progress.path.as_ref().unwrap(),
+                        binary_file_in_progress.length.unwrap(),
+                        read_bytes
+                    );
+                }
+                if let Err(e) = binary_file_in_progress
+                    .digest
+                    .as_ref()
+                    .unwrap()
+                    .compare_data(&binary_file_in_progress.contents.as_ref().unwrap())
+                {
+                    bail!(
+                        "Got binaryfile (path {}) with invalid digest: {:?}",
+                        binary_file_in_progress.path.as_ref().unwrap(),
+                        e
+                    );
+                }
+
+                deploy_binaryfile(binary_file_in_progress).context("Error deploying binaryfile")?;
+                binary_file_in_progress = BinaryFileInProgress::new();
+            }
         }
     }
 
     // Do SSH
-    if active_modules.iter().any(|name| name == "sshkey") {
+    if active_modules.contains("sshkey") {
         log::debug!("SSHkey module was active, installing SSH key");
         if sshkey_user.is_none() || sshkey_key.is_none() {
             bail!("SSHkey module missing username or key");
@@ -173,7 +334,7 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
     }
 
     // Perform RHSM
-    if active_modules.iter().any(|name| name == "rhsm") {
+    if active_modules.contains("rhsm") {
         log::debug!("RHSM module was active, running RHSM");
         if rhsm_organization_id.is_none()
             || rhsm_activation_key.is_none()

--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -25,6 +25,7 @@ fn find_available_modules() -> Result<Vec<String>> {
         "devmod".to_string(),
         "sshkey".to_string(),
         "binaryfile".to_string(),
+        "command".to_string(),
     ];
 
     // See if we add RHSM
@@ -120,38 +121,6 @@ fn perform_rhsm(organization_id: &str, activation_key: &str, perform_insights: b
     Ok(())
 }
 
-fn deploy_binaryfile(file: BinaryFileInProgress) -> Result<()> {
-    let path = file.path.as_ref().unwrap();
-
-    let path = if let Ok(val) = env::var("BINARYFILE_PATH_PREFIX") {
-        PathBuf::from(&val).join(path)
-    } else {
-        PathBuf::from(path)
-    };
-
-    if !path.is_absolute() {
-        bail!("Binaryfile path must be absolute");
-    }
-
-    let contents = file.contents.as_ref().unwrap();
-    let mode = file.mode.unwrap_or(0o600);
-
-    log::info!(
-        "Creating file {:?} with {} bytes (mode {:?})",
-        path,
-        file.length.unwrap(),
-        mode
-    );
-
-    let mut file = File::create(path).context("Error creating file")?;
-    file.write_all(contents).context("Error writing file")?;
-    file.set_permissions(Permissions::from_mode(mode))
-        .context("Error setting file permissions")?;
-    file.sync_all().context("Error syncing file")?;
-
-    Ok(())
-}
-
 #[derive(Debug)]
 struct BinaryFileInProgress {
     path: Option<String>,
@@ -171,9 +140,101 @@ impl BinaryFileInProgress {
             digest: None,
         }
     }
+
+    fn deploy(self) -> Result<()> {
+        let path = self.path.as_ref().unwrap();
+
+        let path = if let Ok(val) = env::var("BINARYFILE_PATH_PREFIX") {
+            PathBuf::from(&val).join(path)
+        } else {
+            PathBuf::from(path)
+        };
+
+        if !path.is_absolute() {
+            bail!("Binary file path must be absolute");
+        }
+
+        let contents = self.contents.as_ref().unwrap();
+        let mode = self.mode.unwrap_or(0o600);
+
+        log::info!(
+            "Creating file {:?} with {} bytes (mode {:?})",
+            path,
+            self.length.unwrap(),
+            mode
+        );
+
+        let mut file = File::create(path).context("Error creating file")?;
+        file.write_all(contents).context("Error writing file")?;
+        file.set_permissions(Permissions::from_mode(mode))
+            .context("Error setting file permissions")?;
+        file.sync_all().context("Error syncing file")?;
+
+        Ok(())
+    }
 }
 
-async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
+#[derive(Debug)]
+struct CommandInProgress {
+    command: Option<String>,
+    args: Vec<String>,
+    may_fail: bool,
+    return_stdout: bool,
+    return_stderr: bool,
+}
+
+impl CommandInProgress {
+    fn new() -> Self {
+        CommandInProgress {
+            command: None,
+            args: Vec::new(),
+            may_fail: false,
+            return_stdout: false,
+            return_stderr: false,
+        }
+    }
+
+    fn execute(self, si_out: &mut ServiceInfo) -> Result<()> {
+        si_out.add("command", "command", self.command.as_ref().unwrap())?;
+        si_out.add("args", "args", &self.args)?;
+
+        let mut cmd = Command::new(self.command.as_ref().unwrap());
+        cmd.args(&self.args);
+
+        if !self.return_stdout {
+            cmd.stdout(std::process::Stdio::null());
+        }
+        if !self.return_stderr {
+            cmd.stderr(std::process::Stdio::null());
+        }
+
+        let output = cmd.output().context("Error running command")?;
+
+        if self.return_stdout {
+            si_out.add(
+                "command",
+                "stdout",
+                &serde_bytes::Bytes::new(&output.stdout),
+            )?;
+        }
+        if self.return_stderr {
+            si_out.add(
+                "command",
+                "stderr",
+                &serde_bytes::Bytes::new(&output.stderr),
+            )?;
+        }
+        si_out.add("command", "exit_code", &output.status.code())?;
+
+        if self.may_fail || output.status.success() {
+            Ok(())
+        } else {
+            bail!("Command failed")
+        }
+    }
+}
+
+async fn process_serviceinfo_in(si_in: &ServiceInfo, si_out: &mut ServiceInfo) -> Result<()> {
     let mut active_modules: HashSet<String> = HashSet::new();
 
     let mut sshkey_user: Option<String> = None;
@@ -184,6 +245,7 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
     let mut rhsm_perform_insights: Option<bool> = None;
 
     let mut binary_file_in_progress = BinaryFileInProgress::new();
+    let mut command_in_progress = CommandInProgress::new();
 
     for (module, key, value) in si_in.iter() {
         log::trace!("Got module {}, command {}, value {:?}", module, key, value);
@@ -230,7 +292,7 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
             if key == "name" {
                 if binary_file_in_progress.path.is_some() {
                     bail!(
-                        "Got binaryfile path {:?} after path {:?}",
+                        "Got binary file path {:?} after path {:?}",
                         value,
                         binary_file_in_progress.path
                     );
@@ -238,46 +300,46 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
                 binary_file_in_progress.path = Some(
                     value
                         .as_str()
-                        .context("Error parsing binaryfile name")?
+                        .context("Error parsing binary file name")?
                         .to_string(),
                 );
             } else if key == "length" {
                 if binary_file_in_progress.length.is_some() {
                     bail!(
-                        "Got binaryfile length {:?} after length {:?}",
+                        "Got binary file length {:?} after length {:?}",
                         value,
                         binary_file_in_progress.length
                     );
                 }
                 binary_file_in_progress.length =
-                    Some(value.as_u64().context("Error parsing binaryfile length")?);
+                    Some(value.as_u64().context("Error parsing binary file length")?);
                 binary_file_in_progress.contents = Some(Vec::with_capacity(
                     binary_file_in_progress.length.unwrap() as usize,
                 ));
             } else if key.starts_with("data") {
                 if binary_file_in_progress.contents.is_none() {
-                    bail!("Got binaryfile data before length {:?}", value);
+                    bail!("Got binary file data before length {:?}", value);
                 }
                 binary_file_in_progress
                     .contents
                     .as_mut()
                     .unwrap()
-                    .extend_from_slice(value.as_bytes().context("Error parsing binaryfile data")?);
+                    .extend_from_slice(value.as_bytes().context("Error parsing binary file data")?);
             } else if key == "mode" {
                 if binary_file_in_progress.mode.is_some() {
                     bail!(
-                        "Got binaryfile mode {:?} after mode {:?}",
+                        "Got binary file mode {:?} after mode {:?}",
                         value,
                         binary_file_in_progress.mode
                     );
                 }
                 binary_file_in_progress.mode =
-                    Some(value.as_u32().context("Error parsing binaryfile mode")?);
+                    Some(value.as_u32().context("Error parsing binary file mode")?);
             } else if key.starts_with("sha-") {
                 let sha_type = key.split('-').nth(1).unwrap();
                 let sha_value = value
                     .as_bytes()
-                    .with_context(|| format!("Error parsing binaryfile sha-{} value", sha_type))?;
+                    .with_context(|| format!("Error parsing binary file sha-{} value", sha_type))?;
                 let hasher = match sha_type {
                     "256" => HashType::Sha256,
                     "384" => HashType::Sha384,
@@ -290,15 +352,15 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
 
                 // We got the full file, check it and add it to the files to get deployed
                 if binary_file_in_progress.path.is_none() {
-                    bail!("Got binaryfile sha-{} before name", sha_type);
+                    bail!("Got binary file sha-{} before name", sha_type);
                 }
                 if binary_file_in_progress.length.is_none() {
-                    bail!("Got binaryfile sha-{} before length", sha_type);
+                    bail!("Got binary file sha-{} before length", sha_type);
                 }
                 let read_bytes = binary_file_in_progress.contents.as_ref().unwrap().len();
                 if read_bytes != binary_file_in_progress.length.unwrap() as usize {
                     bail!(
-                        "Got binaryfile (path {}) with length {} but only {} bytes of data",
+                        "Got binary file (path {}) with length {} but only {} bytes of data",
                         binary_file_in_progress.path.as_ref().unwrap(),
                         binary_file_in_progress.length.unwrap(),
                         read_bytes
@@ -308,17 +370,50 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
                     .digest
                     .as_ref()
                     .unwrap()
-                    .compare_data(&binary_file_in_progress.contents.as_ref().unwrap())
+                    .compare_data(binary_file_in_progress.contents.as_ref().unwrap())
                 {
                     bail!(
-                        "Got binaryfile (path {}) with invalid digest: {:?}",
+                        "Got binary file (path {}) with invalid digest: {:?}",
                         binary_file_in_progress.path.as_ref().unwrap(),
                         e
                     );
                 }
 
-                deploy_binaryfile(binary_file_in_progress).context("Error deploying binaryfile")?;
+                binary_file_in_progress
+                    .deploy()
+                    .context("Error deploying binary file")?;
                 binary_file_in_progress = BinaryFileInProgress::new();
+            }
+        } else if module == "command" {
+            if key == "command" {
+                if command_in_progress.command.is_some() {
+                    bail!(
+                        "Got command {:?} after command {:?}",
+                        value,
+                        command_in_progress.command
+                    );
+                }
+                command_in_progress.command =
+                    Some(value.as_str().context("Error parsing command")?.to_string());
+            } else if key == "args" {
+                command_in_progress.args =
+                    value.as_str_array().context("Error parsing command args")?;
+            } else if key == "may_fail" {
+                command_in_progress.may_fail =
+                    value.as_bool().context("Error parsing command may_fail")?;
+            } else if key == "return_stdout" {
+                command_in_progress.return_stdout = value
+                    .as_bool()
+                    .context("Error parsing command return_stdout")?;
+            } else if key == "return_stderr" {
+                command_in_progress.return_stderr = value
+                    .as_bool()
+                    .context("Error parsing command return_stderr")?;
+            } else if key == "execute" {
+                command_in_progress
+                    .execute(si_out)
+                    .context("Error executing command")?;
+                command_in_progress = CommandInProgress::new();
             }
         }
     }
@@ -355,9 +450,9 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo) -> Result<()> {
 
 pub(crate) async fn perform_to2_serviceinfos(client: &mut ServiceClient) -> Result<()> {
     let mut loop_num = 0;
-    while loop_num < MAX_SERVICE_INFO_LOOPS {
-        let mut out_si = ServiceInfo::new();
+    let mut out_si = ServiceInfo::new();
 
+    while loop_num < MAX_SERVICE_INFO_LOOPS {
         if loop_num == 0 {
             let modules = find_available_modules().context("Error getting list of modules")?;
             let sysinfo = sys_info::linux_os_release()
@@ -374,10 +469,11 @@ pub(crate) async fn perform_to2_serviceinfos(client: &mut ServiceClient) -> Resu
             out_si.add_modules(&modules)?;
         }
 
-        let out_si = DeviceServiceInfo::new(false, out_si);
-        log::trace!("Sending ServiceInfo loop {}: {:?}", loop_num, out_si);
+        let send_si = DeviceServiceInfo::new(false, out_si);
+        out_si = ServiceInfo::new();
+        log::trace!("Sending ServiceInfo loop {}: {:?}", loop_num, send_si);
 
-        let return_si: RequestResult<OwnerServiceInfo> = client.send_request(out_si, None).await;
+        let return_si: RequestResult<OwnerServiceInfo> = client.send_request(send_si, None).await;
         let return_si =
             return_si.with_context(|| format!("Error during ServiceInfo loop {}", loop_num))?;
         log::trace!("Got ServiceInfo loop {}: {:?}", loop_num, return_si);
@@ -392,7 +488,7 @@ pub(crate) async fn perform_to2_serviceinfos(client: &mut ServiceClient) -> Resu
         }
 
         // Process
-        process_serviceinfo_in(return_si.service_info())
+        process_serviceinfo_in(return_si.service_info(), &mut out_si)
             .await
             .context("Error processing returned serviceinfo")?;
 

--- a/data-formats/src/devicecredential/file.rs
+++ b/data-formats/src/devicecredential/file.rs
@@ -39,7 +39,7 @@ impl DeviceCredential for FileDeviceCredential {
         let mut hmac_signer = Signer::new(hmac_type.get_md(), &hmac_key)?;
         hmac_signer.update(data)?;
         let ov_hmac = hmac_signer.sign_to_vec()?;
-        let ov_hmac = HMac::from_digest(hmac_type, ov_hmac);
+        let ov_hmac = HMac::from_digest(hmac_type, ov_hmac)?;
 
         if &ov_hmac != hmac {
             Err(Error::IncorrectHash)

--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -447,6 +447,7 @@ pub trait CborSimpleTypeExt {
     fn as_u64(&self) -> Option<u64>;
     fn as_f64(&self) -> Option<f64>;
     fn as_str(&self) -> Option<&str>;
+    fn as_str_array(&self) -> Option<Vec<String>>;
 }
 
 impl CborSimpleTypeExt for CborSimpleType {
@@ -495,6 +496,24 @@ impl CborSimpleTypeExt for CborSimpleType {
     fn as_str(&self) -> Option<&str> {
         match self {
             serde_cbor::Value::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn as_str_array(&self) -> Option<Vec<String>> {
+        match self {
+            serde_cbor::Value::Array(a) => {
+                let mut out = Vec::new();
+
+                for item in a {
+                    match item {
+                        serde_cbor::Value::Text(s) => out.push(s.to_string()),
+                        _ => return None,
+                    }
+                }
+
+                Some(out)
+            }
             _ => None,
         }
     }

--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -10,8 +10,14 @@ owner_addresses_path: {{ config_dir }}/owner-addresses.yml
 report_to_rendezvous_endpoint_enabled: true
 bind: {{ bind }}
 service_info:
-  rhsm_organization_id: 6454383
+  rhsm_organization_id: 123456
   rhsm_activation_key: SDOkey
   rhsm_run_insights: true
   sshkey_user: {{ user }}
   sshkey_key: "testkey"
+  files:
+  - path: hosts
+    permissions: 644
+    source_path: /etc/hosts
+  - path: resolv.conf
+    source_path: /etc/resolv.conf

--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -21,3 +21,18 @@ service_info:
     source_path: /etc/hosts
   - path: resolv.conf
     source_path: /etc/resolv.conf
+  commands:
+  - command: ls
+    args:
+    - /etc/hosts
+    return_stdout: true
+    return_stderr: true
+  - command: ls
+    args:
+    - /etc/doesnotexist/whatever.foo
+    may_fail: true
+    return_stdout: true
+    return_stderr: true
+  - command: touch
+    args:
+    - {{ keys_path }}/command-testfile

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -210,6 +210,8 @@ testkey
         .context("Error reading hosts file")?;
     assert_eq!(hosts_metadata.permissions().mode() & 0o777, 0o644);
 
+    assert!(key_path.join("command-testfile").exists());
+
     Ok(())
 }
 

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -1,5 +1,5 @@
 mod common;
-use std::{fs, path::Path, time::Duration};
+use std::{fs, os::unix::prelude::PermissionsExt, path::Path, time::Duration};
 
 use common::{Binary, LogSide, TestContext};
 
@@ -156,6 +156,10 @@ async fn test_to() -> Result<()> {
 
     let ssh_authorized_keys_path = ctx.testpath().join("authorized_keys");
     let marker_file_path = ctx.testpath().join("marker");
+    let binary_file_path_prefix = ctx.testpath().join("binary_files");
+
+    std::fs::create_dir(&binary_file_path_prefix).context("Error creating binary_files dir")?;
+
     let output = ctx
         .run_client(
             Binary::ClientLinuxapp,
@@ -163,6 +167,10 @@ async fn test_to() -> Result<()> {
             |cfg| {
                 cfg.env("DEVICE_CREDENTIAL", dc_path.to_str().unwrap())
                     .env("SSH_KEY_PATH", &ssh_authorized_keys_path.to_str().unwrap())
+                    .env(
+                        "BINARYFILE_PATH_PREFIX",
+                        binary_file_path_prefix.to_str().unwrap(),
+                    )
                     .env(
                         "DEVICE_ONBOARDING_EXECUTED_MARKER_FILE_PATH",
                         &marker_file_path.to_str().unwrap(),
@@ -188,6 +196,19 @@ testkey
 # End of FIDO Device Onboarding keys
 "
     );
+
+    assert!(binary_file_path_prefix.join("resolv.conf").exists());
+    let resolv_conf_metadata = binary_file_path_prefix
+        .join("resolv.conf")
+        .metadata()
+        .context("Error reading hosts file")?;
+    assert_eq!(resolv_conf_metadata.permissions().mode() & 0o777, 0o600);
+    assert!(binary_file_path_prefix.join("hosts").exists());
+    let hosts_metadata = binary_file_path_prefix
+        .join("hosts")
+        .metadata()
+        .context("Error reading hosts file")?;
+    assert_eq!(hosts_metadata.permissions().mode() & 0o777, 0o644);
 
     Ok(())
 }

--- a/manufacturing-client/src/main.rs
+++ b/manufacturing-client/src/main.rs
@@ -440,7 +440,7 @@ impl KeyReference {
                 let hmac = hmac_signer
                     .sign_to_vec()
                     .context("Error finalizing hmac computation")?;
-                Ok(HMac::from_digest(HashType::HmacSha384, hmac))
+                Ok(HMac::from_digest(HashType::HmacSha384, hmac)?)
             }
         }
     }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -16,6 +16,7 @@ openssl = "0.10"
 warp = "0.3"
 serde_cbor = "0.11"
 log = "0.4"
+serde_bytes = "0.11"
 serde_yaml = "0.8"
 time = "0.3"
 

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -457,7 +457,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
     let ov_hmac = hmac_signer
         .sign_to_vec()
         .context("Error computing hmac signature")?;
-    let ov_hmac = HMac::from_digest(HashType::HmacSha384, ov_hmac);
+    let ov_hmac = HMac::from_digest(HashType::HmacSha384, ov_hmac)?;
 
     // Build the Ownership Voucher
     let ov = OwnershipVoucher::new(ov_header, ov_hmac, Some(device_cert_chain))


### PR DESCRIPTION
This implements a base `binaryfile` and `command` serviceinfo module set.
Both of them are currently quite hardwired on the server, but that can be changed later when the service info API gets implemented.