### PR TITLE
chore: don't call .to_string() in a format argument

### DIFF
--- a/store/src/directory.rs
+++ b/store/src/directory.rs
@@ -229,7 +229,7 @@ where
             Err(e) => {
                 return Err(StoreError::Unspecified(format!(
                     "Error opening file: {}",
-                    e.to_string()
+                    e,
                 )))
             }
             Ok(f) => f,
@@ -273,7 +273,7 @@ where
             Err(e) => {
                 return Err(StoreError::Unspecified(format!(
                     "Error opening file: {}",
-                    e.to_string()
+                    e,
                 )))
             }
             Ok(f) => f,
@@ -306,7 +306,7 @@ where
             Err(e) => {
                 return Err(StoreError::Unspecified(format!(
                     "Error opening file: {}",
-                    e.to_string()
+                    e,
                 )))
             }
             Ok(f) => f,


### PR DESCRIPTION
There is now a lint that checks for this, since when running format!,
there's no need for a to_string().

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>