### PR TITLE
chore(dracut): strenghten manufacturing client service

### DIFF
--- a/dracut/52fdo/manufacturing-client-service
+++ b/dracut/52fdo/manufacturing-client-service
@@ -4,7 +4,8 @@ set -e
 
 /usr/bin/fdo-manufacturing-client
 mkdir -p /bootmount
-TYPE=$(lsblk --output FSTYPE /dev/disk/by-label/boot | tail -n1)
+udevadm settle
+TYPE=$(blkid -p /dev/disk/by-label/boot -s TYPE -o value)
 mount -t ${TYPE} /dev/disk/by-label/boot /bootmount
 cp -a /etc/device-credentials /bootmount/device-credentials
 cat >"/bootmount/fdo-client-env" <<EOF


### PR DESCRIPTION
lsblk has hiccups on rhel9 for instance, use blkid instead

Signed-off-by: Antonio Murdaca <runcom@linux.com>