### PR TITLE
chore: bump to version 0.3.0

### DIFF
--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,6 +17,6 @@ passwd = "0.0.1"
 rand = "0.8.4"
 nix = "0.23.0"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["client"] }
-fdo-util = { path = "../util", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["client"] }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -4,7 +4,7 @@
 %global __cargo_is_lib() false
 %global forgeurl https://github.com/fedora-iot/fido-device-onboard-rs
 
-Version:        0.2.0
+Version:        0.3.0
 
 %forgemeta
 
@@ -165,6 +165,9 @@ Summary: FDO Owner tools implementation
 %{_docdir}/fdo/owner-addresses.yml
 
 %changelog
+* Tue Feb 1 2022 Patrick Uiterwijk <puiterwijk@redhat.com> - 0.3.0-1
+- Rebase to 0.3.0
+
 * Fri Dec 10 2021 Patrick Uiterwijk <puiterwijk@redhat.com> - 0.2.0-1
 - Rebase to 0.2.0
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-store = { path = "../store", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-store = { path = "../store", version = "0.3.0" }
 aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 
 #define FDO_DATA_MAJOR 0
-#define FDO_DATA_MINOR 2
+#define FDO_DATA_MINOR 3
 #define FDO_DATA_PATCH 0
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -16,6 +16,6 @@ sys-info = "0.9"
 passwd = "0.0.1"
 rand = "0.8.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["client"] }
-fdo-util = { path = "../util", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["client"] }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ log = "0.4"
 hex = "0.4"
 serde_yaml = "0.8"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["server"] }
-fdo-store = { path = "../store", version = "0.2.0", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.3.0", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -20,7 +20,7 @@ log = "0.4"
 serde_yaml = "0.8"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["server"] }
-fdo-store = { path = "../store", version = "0.2.0", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.3.0", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -15,9 +15,9 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["full"] }
 
-fdo-util = { path = "../util", version = "0.2.0" }
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["client"] }
+fdo-util = { path = "../util", version = "0.3.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["client"] }
 
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.2.0", features = ["server"] }
-fdo-store = { path = "../store", version = "0.2.0" }
-fdo-util = { path = "../util", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server"] }
+fdo-store = { path = "../store", version = "0.3.0" }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fdo-store"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
 
 config = "0.11"
 futures = "0.3"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,7 +13,7 @@ glob = "0.3.0"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.2.0" }
-fdo-store = { path = "../store", version = "0.2.0" }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-store = { path = "../store", version = "0.3.0" }
 serde_yaml = "0.8"
 serde_cbor = "0.11"


### PR DESCRIPTION
Bump the version number to 0.3.0 in preparation of a new release.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>