### PR TITLE
chore(examples/config): fix manufacturing server config

### DIFF
--- a/examples/config/manufacturing-server.yml
+++ b/examples/config/manufacturing-server.yml
@@ -1,5 +1,6 @@
 ---
-session_store_driver: InMemory
+session_store_driver: Directory
+session_store_config: /path/to/sessions/
 ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: /path/to/ownership_vouchers/
 bind: 0.0.0.0:8080


### PR DESCRIPTION
change store driver to Directory, we dropped InMemory
a while ago

Signed-off-by: Antonio Murdaca <runcom@linux.com>