### PR TITLE
chore(examples/config): paths must be absolute

### DIFF
--- a/examples/config/owner-onboarding-server.yml
+++ b/examples/config/owner-onboarding-server.yml
@@ -11,11 +11,11 @@ service_info:
   sshkey_user: admin
   sshkey_key: "testkey"
   files:
-  - path: hosts
+  - path: /device/etc/hosts
     permissions: 644
-    source_path: /etc/hosts
-  - path: resolv.conf
-    source_path: /etc/resolv.conf
+    source_path: /local/etc/hosts
+  - path: /device/etc/resolv.conf
+    source_path: /local/etc/resolv.conf
   commands:
   - command: ls
     args:


### PR DESCRIPTION
lots of questions, make this clear :)

Signed-off-by: Antonio Murdaca <runcom@linux.com>