### PR TITLE
default DEVICE_CREDENTIAL to /etc/device-credentials

### DIFF
--- a/util/src/device_credential_locations.rs
+++ b/util/src/device_credential_locations.rs
@@ -16,6 +16,10 @@ pub fn find() -> Option<Result<Box<dyn UsableDeviceCredentialLocation>>> {
         Box::new(FileSystemPathEnv {
             env_var: "DEVICE_CREDENTIAL".to_string(),
         }),
+        Box::new(FileSystemPath {
+            path: "/etc/device-credentials".to_string(),
+            deactivation_method: DeactivationMethod::Deactivate,
+        }),
     ];
 
     for devcredloc in device_credential_locations {


### PR DESCRIPTION
This will match fdo-linuxclient-app to the fdo-manufacturing-client
behavior.

Fixes-Issue: #203

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
