### PR TITLE
feature: add serviceinfo API client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ members = [
     "manufacturing-client",
     "admin-tool",
 
+    "serviceinfo-api-dev-server",
     "integration-tests",
 ]

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -29,8 +29,9 @@ warp-sessions = { version = "1.0", optional = true }
 time = "0.3"
 
 # Client-side
-reqwest = { version = "0.11", optional = true }
+reqwest = { version = "0.11", optional = true, features = ["native-tls", "json"] }
+url = { version = "2", optional = true }
 
 [features]
 server = ["warp", "warp-sessions", "uuid"]
-client = ["reqwest"]
+client = ["reqwest", "url"]

--- a/http-wrapper/src/client.rs
+++ b/http-wrapper/src/client.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryFrom, str::FromStr};
 
+use serde::Deserialize;
 use thiserror::Error;
 
 use aws_nitro_enclaves_cose::error::CoseError;
@@ -12,6 +13,7 @@ use fdo_data_formats::{
 use crate::EncryptionKeys;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Cryptographic error encrypting/decrypting")]
     Crypto(#[from] CoseError),
@@ -37,9 +39,103 @@ pub enum Error {
     InvalidSequenceRequest,
     #[error("Programming error: invalid message sequence for expected response")]
     InvalidSequenceResponse,
+    #[error("URL parse error: {0:?}")]
+    UrlParseError(#[from] url::ParseError),
+    #[error("The URL {0:?} is not valid: {1:?}")]
+    InvalidUrl(String, &'static str),
 }
 
 pub type RequestResult<MT> = Result<MT, Error>;
+
+#[derive(Debug, Deserialize)]
+pub enum JsonAuthentication {
+    None,
+    BearerToken {
+        token: String,
+    },
+    ClientCertificate {
+        client_certificate: Vec<u8>,
+        password: String,
+    },
+}
+
+#[derive(Debug)]
+pub struct JsonClient {
+    base_url: reqwest::Url,
+    client: reqwest::Client,
+    authentication: JsonAuthentication,
+}
+
+impl JsonClient {
+    pub fn new(base_url: String, authentication: JsonAuthentication) -> RequestResult<Self> {
+        let mut client_builder = reqwest::Client::builder();
+
+        let authentication = if let JsonAuthentication::ClientCertificate {
+            client_certificate,
+            password,
+        } = authentication
+        {
+            let identity = reqwest::tls::Identity::from_pkcs12_der(&client_certificate, &password)?;
+            client_builder = client_builder.identity(identity);
+            // We no longer need to keep track of this
+            JsonAuthentication::None
+        } else {
+            authentication
+        };
+
+        let base_url = reqwest::Url::parse(&base_url)?;
+        if base_url.cannot_be_a_base() {
+            return Err(Error::InvalidUrl(
+                base_url.to_string(),
+                "URL is not a valid base URL",
+            ));
+        }
+
+        Ok(JsonClient {
+            base_url,
+            client: client_builder.build()?,
+            authentication,
+        })
+    }
+
+    pub async fn send_get<'a, QT, OT>(&self, query: QT) -> RequestResult<OT>
+    where
+        QT: IntoIterator<Item = (&'a str, &'a str)>,
+        OT: serde::de::DeserializeOwned,
+    {
+        let mut url = self.base_url.clone();
+
+        let query_str = query
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        url.set_query(Some(&query_str));
+
+        let request_builder = self.client.request(reqwest::Method::GET, url);
+
+        let request_builder = match &self.authentication {
+            JsonAuthentication::None => request_builder,
+            JsonAuthentication::BearerToken { token } => {
+                request_builder.header("Authorization", format!("Bearer {}", token))
+            }
+            JsonAuthentication::ClientCertificate { .. } => {
+                unreachable!("Should not be possible to get here")
+            }
+        };
+
+        let request = request_builder.build()?;
+
+        log::trace!("Sending JSON API request: {:?}", request);
+
+        let resp = self.client.execute(request).await;
+
+        log::trace!("Received JSON API response: {:?}", resp);
+
+        resp?.error_for_status()?.json().await.map_err(Error::from)
+    }
+}
 
 #[derive(Debug)]
 pub struct ServiceClient {

--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -17,30 +17,7 @@ owner_addresses:
     - dns_name: localhost
 report_to_rendezvous_endpoint_enabled: true
 bind: {{ bind }}
-service_info:
-  rhsm_organization_id: 123456
-  rhsm_activation_key: SDOkey
-  rhsm_run_insights: true
-  sshkey_user: {{ user }}
-  sshkey_key: "testkey"
-  files:
-  - path: hosts
-    permissions: 644
-    source_path: /etc/hosts
-  - path: resolv.conf
-    source_path: /etc/resolv.conf
-  commands:
-  - command: ls
-    args:
-    - /etc/hosts
-    return_stdout: true
-    return_stderr: true
-  - command: ls
-    args:
-    - /etc/doesnotexist/whatever.foo
-    may_fail: true
-    return_stdout: true
-    return_stderr: true
-  - command: touch
-    args:
-    - {{ keys_path }}/command-testfile
+service_info_api_url: "http://localhost:{{ serviceinfo_api_server_port }}/device_info"
+service_info_api_authentication:
+  BearerToken:
+    token: TestAuthToken

--- a/integration-tests/templates/serviceinfo-api-dev-server.yml.j2
+++ b/integration-tests/templates/serviceinfo-api-dev-server.yml.j2
@@ -1,0 +1,28 @@
+---
+bind: {{ bind }}
+service_info:
+  initial_user:
+    username: {{ user }}
+    sshkeys:
+    - "testkey"
+  files:
+  - path: hosts
+    permissions: 644
+    source_path: /etc/hosts
+  - path: resolv.conf
+    source_path: /etc/resolv.conf
+  commands:
+  - command: ls
+    args:
+    - /etc/hosts
+    return_stdout: true
+    return_stderr: true
+  - command: ls
+    args:
+    - /etc/doesnotexist/whatever.foo
+    may_fail: true
+    return_stdout: true
+    return_stderr: true
+  - command: touch
+    args:
+    - {{ keys_path }}/command-testfile

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -62,6 +62,7 @@ pub enum Binary {
     ManufacturingClient,
     ManufacturingServer,
     OwnerOnboardingServer,
+    ServiceInfoApiDevServer,
     OwnerTool,
     RendezvousServer,
 }
@@ -73,6 +74,7 @@ impl Binary {
             Binary::ManufacturingClient => "fdo-manufacturing-client",
             Binary::ManufacturingServer => "fdo-manufacturing-server",
             Binary::OwnerOnboardingServer => "fdo-owner-onboarding-server",
+            Binary::ServiceInfoApiDevServer => "fdo-serviceinfo-api-dev-server",
             Binary::OwnerTool => "fdo-owner-tool",
             Binary::RendezvousServer => "fdo-rendezvous-server",
         }
@@ -83,6 +85,7 @@ impl Binary {
             Binary::ManufacturingServer => Some("manufacturing-server.yml"),
             Binary::OwnerOnboardingServer => Some("owner-onboarding-server.yml"),
             Binary::RendezvousServer => Some("rendezvous-server.yml"),
+            Binary::ServiceInfoApiDevServer => Some("serviceinfo-api-dev-server.yml"),
             _ => None,
         }
     }
@@ -90,7 +93,10 @@ impl Binary {
     fn is_server(&self) -> bool {
         matches!(
             self,
-            Binary::OwnerOnboardingServer | Binary::ManufacturingServer | Binary::RendezvousServer
+            Binary::OwnerOnboardingServer
+                | Binary::ManufacturingServer
+                | Binary::RendezvousServer
+                | Binary::ServiceInfoApiDevServer
         )
     }
 

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -107,10 +107,25 @@ where
             |_| Ok(()),
         )
         .context("Error creating rendezvous server")?;
+    let serviceinfo_api_dev_server = ctx
+        .start_test_server(
+            Binary::ServiceInfoApiDevServer,
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |_| Ok(()),
+        )
+        .context("Error creating serviceinfo API dev server")?;
     let owner_onboarding_server = ctx
         .start_test_server(
             Binary::OwnerOnboardingServer,
-            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |cfg| {
+                Ok(cfg.prepare_config_file(None, |cfg| {
+                    cfg.insert(
+                        "serviceinfo_api_server_port",
+                        &serviceinfo_api_dev_server.server_port().unwrap(),
+                    );
+                    Ok(())
+                })?)
+            },
             |cmd| {
                 cmd.env("ALLOW_NONINTEROPERABLE_KDF", &"1");
                 Ok(())

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -19,10 +19,25 @@ async fn test_to() -> Result<()> {
             |_| Ok(()),
         )
         .context("Error creating rendezvous server")?;
+    let serviceinfo_api_dev_server = ctx
+        .start_test_server(
+            Binary::ServiceInfoApiDevServer,
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |_| Ok(()),
+        )
+        .context("Error creating serviceinfo API dev server")?;
     let owner_onboarding_server = ctx
         .start_test_server(
             Binary::OwnerOnboardingServer,
-            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |cfg| {
+                Ok(cfg.prepare_config_file(None, |cfg| {
+                    cfg.insert(
+                        "serviceinfo_api_server_port",
+                        &serviceinfo_api_dev_server.server_port().unwrap(),
+                    );
+                    Ok(())
+                })?)
+            },
             |cmd| {
                 cmd.env("ALLOW_NONINTEROPERABLE_KDF", &"1");
                 Ok(())

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -19,8 +19,9 @@ serde_cbor = "0.11"
 log = "0.4"
 serde_yaml = "0.8"
 time = "0.3"
+hex = "0.4"
 
 fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server"] }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server", "client"] }
 fdo-store = { path = "../store", version = "0.3.0", features = ["directory"] }
 fdo-util = { path = "../util", version = "0.3.0" }

--- a/owner-onboarding-server/src/handlers.rs
+++ b/owner-onboarding-server/src/handlers.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 
-use fdo_data_formats::messages;
+use fdo_data_formats::messages::{self, v11::to2::OwnerServiceInfo};
 use fdo_data_formats::{
     constants::{DeviceSigType, ErrorCode, HeaderKeys},
     messages::Message,
@@ -15,9 +15,7 @@ use fdo_http_wrapper::server::Error;
 use fdo_http_wrapper::server::RequestInformation;
 use fdo_http_wrapper::EncryptionKeys;
 use fdo_store::MetadataKey;
-use fdo_util::servers::OwnershipVoucherStoreMetadataKey;
-
-use crate::serviceinfo::perform_service_info;
+use fdo_util::servers::{OwnershipVoucherStoreMetadataKey, ServiceInfoApiReply};
 
 pub(super) async fn hello_device(
     user_data: super::OwnerServiceUDT,
@@ -439,21 +437,118 @@ pub(super) async fn device_service_info(
         num_loops
     );
 
-    let resp =
-        match perform_service_info(user_data, &mut ses_with_store.session, msg, num_loops).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("Error during performing service info: {:?}", e);
-                return Err(Error::new(
-                    ErrorCode::InternalServerError,
-                    messages::v11::to2::DeviceServiceInfo::message_type(),
-                    "Error handling serviceinfo",
-                )
-                .into());
-            }
-        };
+    let resp = match perform_service_info(
+        user_data,
+        &mut ses_with_store.session,
+        device_guid,
+        msg,
+        num_loops,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("Error during performing service info: {:?}", e);
+            return Err(Error::new(
+                ErrorCode::InternalServerError,
+                messages::v11::to2::DeviceServiceInfo::message_type(),
+                "Error handling serviceinfo",
+            )
+            .into());
+        }
+    };
 
     Ok((resp, ses_with_store))
+}
+
+async fn perform_service_info(
+    user_data: super::OwnerServiceUDT,
+    _session: &mut fdo_http_wrapper::server::Session,
+    device_guid: Guid,
+    msg: messages::v11::to2::DeviceServiceInfo,
+    loop_num: u32,
+) -> Result<OwnerServiceInfo, anyhow::Error> {
+    if loop_num != 0 {
+        // Return DONE for now after the first loop.
+        return Ok(messages::v11::to2::OwnerServiceInfo::new(
+            false,
+            true,
+            Default::default(),
+        ));
+    }
+    let in_si = msg.service_info();
+
+    log::trace!("Received ServiceInfo loop {}: {:?}", loop_num, in_si);
+
+    let mut module_list: Option<Vec<String>> = None;
+
+    for (module, var, value) in in_si.iter() {
+        if module == "devmod" && var == "modules" {
+            let mut rawmodlist: Vec<serde_cbor::Value> = serde_cbor::value::from_value(value)?;
+            log::trace!("Received module list: {:?}", rawmodlist);
+
+            // Skip the first two items.... They are integers :()
+            let mut modlist: HashSet<String> = HashSet::new();
+            for rawmod in rawmodlist.drain(..).skip(2) {
+                modlist.insert(serde_cbor::value::from_value(rawmod)?);
+            }
+            log::trace!("Module list: {:?}", modlist);
+
+            module_list = Some(modlist.into_iter().collect());
+        }
+    }
+
+    let module_list = match module_list {
+        None => {
+            log::error!("No module list found in ServiceInfo");
+            anyhow::bail!("No module list found in ServiceInfo");
+        }
+        Some(l) => l,
+    };
+
+    let resp: ServiceInfoApiReply = user_data
+        .service_info_api_client
+        .send_get([
+            ("serviceinfo_api_version", "1"),
+            ("device_guid", &device_guid.to_string()),
+            ("modules", &module_list.join(",")),
+        ])
+        .await?;
+
+    log::trace!("ServiceInfo API reply: {:?}", resp);
+
+    let mut out_si = fdo_data_formats::types::ServiceInfo::new();
+
+    if let Some(initial_user) = resp.initial_user {
+        out_si.add("sshkey", "active", &true)?;
+        out_si.add("sshkey", "username", &initial_user.username)?;
+        for key in initial_user.ssh_keys.iter() {
+            out_si.add("sshkey", "key", &key)?;
+        }
+    }
+
+    if let Some(extra_commands) = resp.extra_commands {
+        for (module, key, value) in extra_commands {
+            if key.ends_with("|hex") {
+                let value = hex::decode(
+                    &value
+                        .as_str()
+                        .ok_or_else(|| anyhow::anyhow!("Invalid API response: non-hex"))?,
+                )?;
+                let value = serde_bytes::ByteBuf::from(value);
+                let key = key.replace("|hex", "");
+                out_si.add(&module, &key, &value)?;
+            } else {
+                out_si.add(&module, &key, &value)?;
+            }
+        }
+    }
+
+    log::trace!("Sending ServiceInfo result: {:?}", out_si);
+
+    Ok(messages::v11::to2::OwnerServiceInfo::new(
+        false, false, out_si,
+    ))
 }
 
 pub(super) async fn done(

--- a/serviceinfo-api-dev-server/Cargo.toml
+++ b/serviceinfo-api-dev-server/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fdo-serviceinfo-api-dev-server"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+config = "0.11"
+hex = "0.4"
+tokio = { version = "1", features = ["full"] }
+warp = "0.3"
+log = "0.4"
+serde = "1"
+serde_bytes = "0.11"
+serde_json = "1"
+
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
+fdo-util = { path = "../util", version = "0.3.0" }

--- a/serviceinfo-api-dev-server/src/main.rs
+++ b/serviceinfo-api-dev-server/src/main.rs
@@ -1,0 +1,300 @@
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    str::FromStr,
+};
+
+use anyhow::{Context, Result};
+use fdo_data_formats::{constants::HashType, types::Hash};
+use serde::Deserialize;
+use tokio::signal::unix::{signal, SignalKind};
+use warp::Filter;
+
+use fdo_util::servers::{settings_for, ServiceInfoApiReply, ServiceInfoApiReplyInitialUser};
+
+#[derive(Debug, Deserialize, Clone)]
+struct ServiceInfoFile {
+    path: String,
+    permissions: Option<String>,
+    #[serde(skip)]
+    parsed_permissions: Option<u32>,
+    #[serde(skip)]
+    contents_len: usize,
+    #[serde(skip)]
+    contents_hex: String,
+    #[serde(skip)]
+    hash_hex: String,
+    source_path: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ServiceInfoCommand {
+    command: String,
+    args: Vec<String>,
+    #[serde(default)]
+    may_fail: bool,
+    #[serde(default)]
+    return_stdout: bool,
+    #[serde(default)]
+    return_stderr: bool,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ServiceInfoInitialUser {
+    username: String,
+    sshkeys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ServiceInfoSettings {
+    initial_user: Option<ServiceInfoInitialUser>,
+
+    files: Option<Vec<ServiceInfoFile>>,
+
+    commands: Option<Vec<ServiceInfoCommand>>,
+
+    additional_serviceinfo: Option<HashMap<String, Vec<(String, String)>>>,
+}
+
+#[derive(Debug)]
+struct ServiceInfoConfiguration {
+    settings: ServiceInfoSettings,
+}
+
+impl ServiceInfoConfiguration {
+    fn from_settings(mut settings: ServiceInfoSettings) -> Result<Self> {
+        // Perform checks on the configuration
+
+        // Check permissions for files are valid
+        settings.files = if let Some(files) = settings.files {
+            let mut new_files = Vec::new();
+
+            for mut file in files {
+                let path = &file.path;
+
+                file.parsed_permissions = if let Some(permissions) = &file.permissions {
+                    Some(u32::from_str_radix(permissions, 8).with_context(|| {
+                        format!(
+                            "Invalid permission string for file {}: {} (invalid octal)",
+                            path, permissions
+                        )
+                    })?)
+                } else {
+                    None
+                };
+
+                let contents = std::fs::read(&file.source_path)
+                    .with_context(|| format!("Failed to read file {}", file.source_path))?;
+                file.hash_hex = hex::encode(
+                    &Hash::from_data(HashType::Sha384, &contents)
+                        .with_context(|| format!("Failed to hash file {}", file.source_path))?
+                        .value_bytes(),
+                );
+                file.contents_len = contents.len();
+                file.contents_hex = hex::encode(&contents);
+
+                new_files.push(file);
+            }
+
+            Some(new_files)
+        } else {
+            None
+        };
+
+        Ok(ServiceInfoConfiguration { settings })
+    }
+}
+
+const AUTHENTICATION_TOKEN: &str = "Bearer TestAuthToken";
+
+#[derive(Debug, Deserialize)]
+struct Settings {
+    service_info: ServiceInfoSettings,
+    bind: String,
+}
+
+struct ServiceInfoApiDevServerUD {
+    service_info_configuration: ServiceInfoConfiguration,
+}
+
+type ServiceInfoApiDevServerUDT = std::sync::Arc<ServiceInfoApiDevServerUD>;
+
+#[derive(Debug, Default)]
+struct ServiceInfoApiReplyBuilder {
+    enabled_modules: std::collections::HashSet<String>,
+    reply: ServiceInfoApiReply,
+}
+
+impl ServiceInfoApiReplyBuilder {
+    fn add_extra<T>(&mut self, module: &str, command: &str, argument: &T)
+    where
+        T: serde::Serialize,
+    {
+        if self.reply.extra_commands.is_none() {
+            self.reply.extra_commands = Some(Vec::new());
+        }
+        if !self.enabled_modules.contains(module) {
+            self.enabled_modules.insert(module.to_string());
+            self.reply.extra_commands.as_mut().unwrap().push((
+                module.to_string(),
+                "active".to_string(),
+                serde_json::Value::Bool(true),
+            ));
+        }
+
+        self.reply.extra_commands.as_mut().unwrap().push((
+            module.to_string(),
+            command.to_string(),
+            serde_json::to_value(argument).expect("Error converting to json value"),
+        ));
+    }
+}
+
+async fn serviceinfo_handler(
+    user_data: ServiceInfoApiDevServerUDT,
+    query_info: QueryInfo,
+) -> Result<warp::reply::Json, warp::Rejection> {
+    if query_info.api_version != 1 {
+        log::warn!(
+            "Unsupported API version {} requested",
+            query_info.api_version
+        );
+        return Err(warp::reject::reject());
+    }
+    log::info!(
+        "ServiceInfo (api version {}) request for device {:?}, modules {:?}",
+        query_info.api_version,
+        query_info.device_guid,
+        query_info.modules
+    );
+
+    let mut reply: ServiceInfoApiReplyBuilder = Default::default();
+
+    if query_info.modules.contains("sshkey") {
+        if let Some(initial_user) = &user_data.service_info_configuration.settings.initial_user {
+            reply.reply.initial_user = Some(ServiceInfoApiReplyInitialUser {
+                username: initial_user.username.clone(),
+                ssh_keys: initial_user.sshkeys.clone(),
+            });
+        }
+    }
+
+    if query_info.modules.contains("binaryfile") {
+        if let Some(files) = &user_data.service_info_configuration.settings.files {
+            for file in files {
+                reply.add_extra("binaryfile", "name", &file.path);
+                reply.add_extra("binaryfile", "length", &file.contents_len);
+                if let Some(parsed_permissions) = &file.parsed_permissions {
+                    reply.add_extra("binaryfile", "mode", &parsed_permissions);
+                }
+                reply.add_extra("binaryfile", "data001|hex", &file.contents_hex);
+                reply.add_extra("binaryfile", "sha-384|hex", &file.hash_hex);
+            }
+        }
+    }
+
+    if query_info.modules.contains("command") {
+        if let Some(commands) = &user_data.service_info_configuration.settings.commands {
+            for command in commands {
+                reply.add_extra("command", "command", &command.command);
+                reply.add_extra("command", "args", &command.args);
+                reply.add_extra("command", "may_fail", &command.may_fail);
+                reply.add_extra("command", "return_stdout", &command.return_stdout);
+                reply.add_extra("command", "return_stderr", &command.return_stderr);
+                reply.add_extra("command", "execute", &true);
+            }
+        }
+    }
+
+    if let Some(additional_serviceinfo) = &user_data
+        .service_info_configuration
+        .settings
+        .additional_serviceinfo
+    {
+        for (module, serviceinfo_lines) in additional_serviceinfo {
+            if query_info.modules.contains(module) {
+                for (key, value) in serviceinfo_lines {
+                    reply.add_extra(module, key, value);
+                }
+            }
+        }
+    }
+
+    Ok(warp::reply::json(&reply.reply))
+}
+
+fn deserialize_from_str<'de, D>(deserializer: D) -> Result<fdo_data_formats::types::Guid, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    FromStr::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+fn deserialize_from_comma_separated_strings<'de, D>(
+    deserializer: D,
+) -> Result<HashSet<String>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Ok(s.split(',').map(|s| s.to_string()).collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryInfo {
+    #[serde(rename = "serviceinfo_api_version")]
+    api_version: u32,
+    #[serde(deserialize_with = "deserialize_from_str")]
+    device_guid: fdo_data_formats::types::Guid,
+    #[serde(deserialize_with = "deserialize_from_comma_separated_strings")]
+    modules: HashSet<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    fdo_util::add_version!();
+    fdo_http_wrapper::init_logging();
+
+    let settings: Settings = settings_for("serviceinfo-api-dev-server")?
+        .try_into()
+        .context("Error parsing configuration")?;
+
+    // Bind information
+    let bind_addr = SocketAddr::from_str(&settings.bind)
+        .with_context(|| format!("Error parsing bind string '{}'", &settings.bind))?;
+
+    // ServiceInfo settings
+    let service_info_configuration = ServiceInfoConfiguration::from_settings(settings.service_info)
+        .context("Error preparing ServiceInfo configuration")?;
+
+    let user_data = std::sync::Arc::new(ServiceInfoApiDevServerUD {
+        service_info_configuration,
+    });
+
+    let serviceinfo = warp::path("device_info")
+        .and(warp::header::exact("Authorization", AUTHENTICATION_TOKEN))
+        .and(warp::query::query::<QueryInfo>())
+        .map(move |queryinfo| (user_data.clone(), queryinfo))
+        .untuple_one()
+        .and_then(serviceinfo_handler);
+
+    let handler_ping = fdo_http_wrapper::server::ping_handler();
+
+    let routes = warp::get()
+        .and(serviceinfo)
+        .or(handler_ping)
+        .with(warp::log("serviceinfo-api-dev-server"));
+
+    log::info!("Listening on {}", bind_addr);
+    let server = warp::serve(routes);
+    let server = server
+        .bind_with_graceful_shutdown(bind_addr, async {
+            signal(SignalKind::terminate()).unwrap().recv().await;
+            log::info!("Terminating");
+        })
+        .1;
+    tokio::join!(server);
+
+    Ok(())
+}

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,3 +17,4 @@ fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
 fdo-store = { path = "../store", version = "0.3.0" }
 serde_yaml = "0.8"
 serde_cbor = "0.11"
+serde_json = "1"

--- a/util/src/servers.rs
+++ b/util/src/servers.rs
@@ -1,5 +1,5 @@
 use glob::glob;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::{env, path::PathBuf};
 
@@ -138,4 +138,18 @@ pub fn yaml_to_cbor(val: &Value) -> Result<CborValue> {
                 .collect(),
         ),
     })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServiceInfoApiReplyInitialUser {
+    pub username: String,
+    pub ssh_keys: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ServiceInfoApiReply {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_user: Option<ServiceInfoApiReplyInitialUser>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_commands: Option<Vec<(String, String, serde_json::Value)>>,
 }


### PR DESCRIPTION
This makes the Owner Onboarding Server use the ServiceInfo API for all
ServiceInfo data.

Fixes: #153
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>