### PR TITLE
embed rendezvous-info and owner-addresses in the config

### DIFF
--- a/examples/config/manufacturing-server.yml
+++ b/examples/config/manufacturing-server.yml
@@ -4,7 +4,15 @@ session_store_config: /path/to/sessions/
 ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: /path/to/ownership_vouchers/
 bind: 0.0.0.0:8080
-rendezvous_info_path: /path/to/rendezvous-info.yml
+rendezvous_info:
+- dns: fdo.example.com
+  device_port: 8082
+  owner_port: 8082
+  protocol: http
+- ip: 127.0.0.1
+  device_port: 8083
+  owner_port: 8083
+  protocol: http
 protocols:
   diun:
     key_path: /path/to/keys/diun_key.der

--- a/examples/config/owner-addresses.yml
+++ b/examples/config/owner-addresses.yml
@@ -1,5 +1,0 @@
----
-- transport: HTTP
-  port: 8081
-  addresses:
-    - dns_name: fdo.example.com

--- a/examples/config/owner-onboarding-server.yml
+++ b/examples/config/owner-onboarding-server.yml
@@ -6,7 +6,11 @@ ownership_voucher_store_config: /path/to/ownership_vouchers/
 trusted_device_keys_path: /path/to/keys/device_ca_cert.pem
 owner_private_key_path: /path/to/keys/owner_key.der
 owner_public_key_path: /path/to/keys/owner_cert.pem
-owner_addresses_path: /path/to/owner-addresses.yml
+owner_addresses:
+- transport: HTTP
+  port: 8081
+  addresses:
+    - dns_name: fdo.example.com
 report_to_rendezvous_endpoint_enabled: false
 bind: 0.0.0.0:8081
 service_info:

--- a/examples/config/owner-onboarding-server.yml
+++ b/examples/config/owner-onboarding-server.yml
@@ -6,6 +6,8 @@ ownership_voucher_store_config: /path/to/ownership_vouchers/
 trusted_device_keys_path: /path/to/keys/device_ca_cert.pem
 owner_private_key_path: /path/to/keys/owner_key.der
 owner_public_key_path: /path/to/keys/owner_cert.pem
+owner_addresses_path: /path/to/owner-addresses.yml
+report_to_rendezvous_endpoint_enabled: false
 bind: 0.0.0.0:8081
 service_info:
   sshkey_user: admin

--- a/examples/config/rendezvous-info.yml
+++ b/examples/config/rendezvous-info.yml
@@ -1,5 +1,0 @@
----
-- dns: fdo.example.com
-  device_port: 8082
-  owner_port: 8082
-  protocol: http

--- a/integration-tests/templates/manufacturing-server.yml.j2
+++ b/integration-tests/templates/manufacturing-server.yml.j2
@@ -4,7 +4,16 @@ session_store_config: {{ config_dir }}/sessions/
 ownership_voucher_store_driver: Directory
 ownership_voucher_store_config: {{ config_dir }}/ownership_vouchers/
 bind: {{ bind }}
-rendezvous_info_path: {{ config_dir }}/rendezvous-info.yml
+rendezvous_info:
+- dns: localhost
+  device_port: 8082
+  owner_port: 8082
+  protocol: http
+- dns: localhost
+  delay: 30
+  device_port: {{ rendezvous_port }}
+  owner_port: {{ rendezvous_port }}
+  protocol: http
 protocols:
   diun:
     key_path: {{ keys_path }}/diun_key.der

--- a/integration-tests/templates/owner-addresses.yml.j2
+++ b/integration-tests/templates/owner-addresses.yml.j2
@@ -1,9 +1,0 @@
----
-- transport: HTTP
-  port: 8079
-  addresses:
-    - dns_name: localhost
-- transport: HTTP
-  port: {{ owner_port }}
-  addresses:
-    - dns_name: localhost

--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -6,7 +6,15 @@ ownership_voucher_store_config: {{ config_dir }}/ownership_vouchers/
 trusted_device_keys_path: {{ keys_path }}/device_ca_cert.pem
 owner_private_key_path: {{ keys_path }}/owner_key.der
 owner_public_key_path: {{ keys_path }}/owner_cert.pem
-owner_addresses_path: {{ config_dir }}/owner-addresses.yml
+owner_addresses:
+- transport: HTTP
+  port: 8079
+  addresses:
+    - dns_name: localhost
+- transport: HTTP
+  port: {{ owner_port }}
+  addresses:
+    - dns_name: localhost
 report_to_rendezvous_endpoint_enabled: true
 bind: {{ bind }}
 service_info:

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -740,6 +740,7 @@ impl<'a> TestServerConfigurator<'a> {
                     &format!("127.0.0.1:{}", self.server_number.server_port().unwrap()),
                 );
                 cfg.insert("owner_port", &self.server_number.server_port().unwrap());
+                cfg.insert("rendezvous_port", &1337);
                 cfg.insert(
                     "config_dir",
                     &self.test_context.runner_path(&self.server_number),

--- a/integration-tests/tests/di_diun.rs
+++ b/integration-tests/tests/di_diun.rs
@@ -14,12 +14,7 @@ async fn test_diun() -> Result<()> {
     let mfg_server = ctx
         .start_test_server(
             Binary::ManufacturingServer,
-            |cfg| {
-                cfg.prepare_config_file(Some("rendezvous-info.yml"), |ctx| {
-                    Ok(ctx.insert("rendezvous_port", &1337))
-                })?;
-                Ok(cfg.prepare_config_file(None, |_| Ok(()))?)
-            },
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
             |_| Ok(()),
         )
         .context("Error creating manufacturing server")?;
@@ -106,12 +101,7 @@ async fn test_device_credentials_already_active() -> Result<()> {
     let mfg_server = ctx
         .start_test_server(
             Binary::ManufacturingServer,
-            |cfg| {
-                cfg.prepare_config_file(Some("rendezvous-info.yml"), |ctx| {
-                    Ok(ctx.insert("rendezvous_port", &1337))
-                })?;
-                Ok(cfg.prepare_config_file(None, |_| Ok(()))?)
-            },
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
             |_| Ok(()),
         )
         .context("Error creating manufacturing server")?;

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -22,10 +22,7 @@ async fn test_to() -> Result<()> {
     let owner_onboarding_server = ctx
         .start_test_server(
             Binary::OwnerOnboardingServer,
-            |cfg| {
-                cfg.prepare_config_file(Some("owner-addresses.yml"), |_| Ok(()))?;
-                Ok(cfg.prepare_config_file(None, |_| Ok(()))?)
-            },
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
             |cmd| {
                 cmd.env("ALLOW_NONINTEROPERABLE_KDF", &"1");
                 Ok(())

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -363,17 +363,11 @@ async fn main() -> Result<()> {
 
     // Owner addresses for report to rendezvous
     let owner_addresses = {
-        let owner_addresses_path = &settings.owner_addresses_path;
         let mut owner_addresses: Vec<RemoteConnection> = {
-            let f = fs::File::open(&owner_addresses_path)?;
+            let f = fs::File::open(settings.owner_addresses_path)?;
             serde_yaml::from_reader(f)
         }
-        .with_context(|| {
-            format!(
-                "Error reading owner addresses from {}",
-                owner_addresses_path
-            )
-        })?;
+        .context("Error reading owner addresses")?;
         let owner_addresses: Result<Vec<Vec<TO2AddressEntry>>> = owner_addresses
             .drain(..)
             .map(|v| v.try_into().context("Error converting owner addresses"))


### PR DESCRIPTION
Easier than having a separate file to link to - this patch still leaves
a rendezvous-info for tests and manual device init, we can revisit
later.

Signed-off-by: Antonio Murdaca <runcom@linux.com>