### PR TITLE
feat: implement semi-TPM Device Credential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    container: fedora:latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache
@@ -58,12 +59,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
+      - name: Install deps
+        run: |
+          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel clippy cargo rust
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -71,7 +69,11 @@ jobs:
 
   build_and_test:
     runs-on: ubuntu-latest
+    container: fedora:latest
     steps:
+      - name: Install deps
+        run: |
+          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel swtpm swtpm-tools cargo rust git
       - uses: actions/checkout@v2
       - name: Cache
         uses: actions/cache@v2

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -23,6 +23,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 paste = "1.0"
 pem = "1.0"
+tss-esapi = "7.0"
 
 http = "0.2"
 hyper = "0.14"

--- a/data-formats/src/devicecredential/file.rs
+++ b/data-formats/src/devicecredential/file.rs
@@ -1,26 +1,172 @@
+use std::{
+    cell::RefCell,
+    convert::{TryFrom, TryInto},
+};
+
 use crate::{
+    constants::HashType,
     errors::Error,
     types::HMac,
     types::{Guid, Hash, RendezvousInfo},
     DeviceCredential, ProtocolVersion,
 };
 
+use aws_nitro_enclaves_cose::{error::CoseError, sign::SignatureAlgorithm};
 use openssl::{pkey::PKey, sign::Signer};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_tuple::Serialize_tuple;
+use tss_esapi::{
+    attributes::ObjectAttributesBuilder, structures::PublicBuilder, traits::UnMarshall,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum KeyStorage {
+    Plain {
+        hmac_secret: Vec<u8>,
+        private_key: Vec<u8>,
+    },
+    Tpm {
+        signing_public: Vec<u8>,
+        signing_private: Vec<u8>,
+        hmac_public: Vec<u8>,
+        hmac_private: Vec<u8>,
+    },
+}
+
+fn get_semi_tpm_ctx_and_primary(
+) -> Result<(tss_esapi::Context, tss_esapi::handles::KeyHandle), Error> {
+    let tcti_conf = tss_esapi::tcti_ldr::TctiNameConf::from_environment_variable()
+        .unwrap_or_else(|_| tss_esapi::tcti_ldr::TctiNameConf::Tabrmd(Default::default()));
+    let mut tss_context = tss_esapi::Context::new(tcti_conf)?;
+
+    let primary_template = semi_tpm_primary_key_template()?;
+    let primary_handle = tss_context
+        .execute_with_nullauth_session(|ctx| {
+            ctx.create_primary(
+                tss_esapi::interface_types::resource_handles::Hierarchy::Owner,
+                primary_template,
+                None,
+                None,
+                None,
+                None,
+            )
+        })?
+        .key_handle;
+    Ok((tss_context, primary_handle))
+}
+
+impl KeyStorage {
+    pub fn perform_hmac(&self, data: &[u8], hmac_type: HashType) -> Result<HMac, Error> {
+        match self {
+            KeyStorage::Plain {
+                ref hmac_secret, ..
+            } => {
+                let hmac_key = PKey::hmac(hmac_secret)?;
+                let mut hmac_signer = Signer::new(hmac_type.get_md(), &hmac_key)?;
+                hmac_signer.update(data)?;
+                let ov_hmac = hmac_signer.sign_to_vec()?;
+                HMac::from_digest(hmac_type, ov_hmac)
+            }
+            KeyStorage::Tpm {
+                hmac_public,
+                hmac_private,
+                ..
+            } => {
+                let (mut tss_context, primary_handle) = get_semi_tpm_ctx_and_primary()?;
+                let hmac_public = tss_esapi::structures::Public::unmarshall(hmac_public)?;
+                let hash_algo = match hmac_public {
+                    tss_esapi::structures::Public::KeyedHash { parameters, .. } => {
+                        let parameters: tss_esapi::tss2_esys::TPMS_KEYEDHASH_PARMS =
+                            parameters.into();
+                        let scheme = parameters.scheme;
+                        match tss_esapi::constants::AlgorithmIdentifier::try_from(scheme.scheme)? {
+                            tss_esapi::constants::AlgorithmIdentifier::Hmac => {}
+                            _ => return Err(Error::UnsupportedAlgorithm),
+                        }
+                        let details = unsafe { scheme.details.hmac }.hashAlg;
+                        let details = tss_esapi::constants::AlgorithmIdentifier::try_from(details)?;
+
+                        match details {
+                            tss_esapi::constants::AlgorithmIdentifier::Sha256 => {
+                                tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256
+                            }
+                            tss_esapi::constants::AlgorithmIdentifier::Sha384 => {
+                                tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha384
+                            }
+                            _ => return Err(Error::UnsupportedAlgorithm),
+                        }
+                    }
+                    _ => return Err(Error::UnsupportedAlgorithm),
+                };
+                let hash_type = match hash_algo {
+                    tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256 => {
+                        HashType::Sha256
+                    }
+                    tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha384 => {
+                        HashType::Sha384
+                    }
+                    _ => return Err(Error::UnsupportedAlgorithm),
+                };
+
+                let hmac_handle = tss_context.execute_with_nullauth_session(|ctx| {
+                    ctx.load(
+                        primary_handle,
+                        hmac_private.as_slice().try_into()?,
+                        hmac_public.clone(),
+                    )
+                })?;
+                let data = data.try_into()?;
+
+                let hmac = tss_context.execute_with_nullauth_session(|ctx| {
+                    ctx.execute_with_temporary_object(hmac_handle.into(), |ctx, hmac_key| {
+                        ctx.hmac(hmac_key, data, hash_algo)
+                    })
+                })?;
+                Ok(HMac::from_digest(hash_type, hmac.to_vec())?)
+            }
+        }
+    }
+}
+
+pub fn semi_tpm_primary_key_template() -> Result<tss_esapi::structures::Public, Error> {
+    let primary_attributes = ObjectAttributesBuilder::new()
+        .with_fixed_tpm(true)
+        .with_user_with_auth(true)
+        .with_fixed_parent(true)
+        .with_sensitive_data_origin(true)
+        .with_restricted(true)
+        .with_decrypt(true)
+        .build()?;
+    PublicBuilder::new()
+        .with_public_algorithm(tss_esapi::interface_types::algorithm::PublicAlgorithm::Ecc)
+        .with_object_attributes(primary_attributes)
+        .with_name_hashing_algorithm(
+            tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256,
+        )
+        .with_ecc_parameters(tss_esapi::structures::PublicEccParameters::new(
+            tss_esapi::structures::SymmetricDefinitionObject::Aes {
+                key_bits: tss_esapi::interface_types::key_bits::AesKeyBits::Aes128,
+                mode: tss_esapi::interface_types::algorithm::SymmetricMode::Cfb,
+            },
+            tss_esapi::structures::EccScheme::Null,
+            tss_esapi::interface_types::ecc::EccCurve::NistP256,
+            tss_esapi::structures::KeyDerivationFunctionScheme::Null,
+        ))
+        .with_ecc_unique_identifier(Default::default())
+        .build()
+        .map_err(Error::from)
+}
 
 #[derive(Debug, Serialize_tuple, Deserialize)]
 pub struct FileDeviceCredential {
     pub active: bool,             // Active
     pub protver: ProtocolVersion, // ProtVer
-    pub hmac_secret: Vec<u8>,     // HmacSecret
     pub device_info: String,      // DeviceInfo
     pub guid: Guid,               // Guid
     pub rvinfo: RendezvousInfo,   // RVInfo
     pub pubkey_hash: Hash,        // PubKeyHash
 
-    // Custom from here
-    pub private_key: Vec<u8>,
+    pub key_storage: KeyStorage,
 }
 
 impl DeviceCredential for FileDeviceCredential {
@@ -33,15 +179,7 @@ impl DeviceCredential for FileDeviceCredential {
     }
 
     fn verify_hmac(&self, data: &[u8], hmac: &HMac) -> Result<(), Error> {
-        let hmac_type = hmac.get_type();
-
-        let hmac_key = PKey::hmac(&self.hmac_secret)?;
-        let mut hmac_signer = Signer::new(hmac_type.get_md(), &hmac_key)?;
-        hmac_signer.update(data)?;
-        let ov_hmac = hmac_signer.sign_to_vec()?;
-        let ov_hmac = HMac::from_digest(hmac_type, ov_hmac)?;
-
-        if &ov_hmac != hmac {
+        if hmac != &self.key_storage.perform_hmac(data, hmac.get_type())? {
             Err(Error::IncorrectHash)
         } else {
             Ok(())
@@ -67,6 +205,189 @@ impl DeviceCredential for FileDeviceCredential {
     fn get_signer(
         &self,
     ) -> Result<Box<dyn aws_nitro_enclaves_cose::crypto::SigningPrivateKey>, Error> {
-        Ok(Box::new(PKey::private_key_from_der(&self.private_key)?))
+        match self.key_storage {
+            KeyStorage::Plain {
+                ref private_key, ..
+            } => Ok(Box::new(PKey::private_key_from_der(private_key)?)),
+            KeyStorage::Tpm {
+                ref signing_public,
+                ref signing_private,
+                ..
+            } => {
+                let (mut tss_context, primary_handle) = get_semi_tpm_ctx_and_primary()?;
+                let signing_public = tss_esapi::structures::Public::unmarshall(signing_public)?;
+
+                let signing_handle = tss_context.execute_with_nullauth_session(|ctx| {
+                    ctx.load(
+                        primary_handle,
+                        signing_private.as_slice().try_into()?,
+                        signing_public.clone(),
+                    )
+                })?;
+
+                Ok(Box::new(TpmCoseSigner {
+                    tss_context: RefCell::new(tss_context),
+                    _primary_handle: primary_handle,
+                    signing_handle,
+                    signing_public,
+                }))
+            }
+        }
+    }
+}
+
+struct TpmCoseSigner {
+    tss_context: RefCell<tss_esapi::Context>,
+    // This is here for the lifetime of the KeyHandle, so it won't be dropped
+    _primary_handle: tss_esapi::handles::KeyHandle,
+    signing_handle: tss_esapi::handles::KeyHandle,
+    signing_public: tss_esapi::structures::Public,
+}
+
+impl TpmCoseSigner {
+    fn public_to_parameters(
+        public: &tss_esapi::structures::Public,
+    ) -> Result<
+        (
+            (SignatureAlgorithm, openssl::hash::MessageDigest),
+            tss_esapi::interface_types::algorithm::HashingAlgorithm,
+            usize,
+        ),
+        aws_nitro_enclaves_cose::error::CoseError,
+    > {
+        match public {
+            tss_esapi::structures::Public::Rsa { .. } => unimplemented!(),
+            tss_esapi::structures::Public::Ecc { parameters, .. } => {
+                let hash_alg = match parameters.ecc_scheme() {
+                    tss_esapi::structures::EccScheme::EcDsa(sig_alg) => sig_alg.hashing_algorithm(),
+                    _ => return Err(CoseError::UnsupportedError("Unsupported ECC scheme".into())),
+                };
+                let param_hash_alg = match hash_alg {
+                    tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256 => {
+                        openssl::hash::MessageDigest::sha256()
+                    }
+                    tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha384 => {
+                        openssl::hash::MessageDigest::sha384()
+                    }
+                    tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha512 => {
+                        openssl::hash::MessageDigest::sha512()
+                    }
+                    _ => {
+                        return Err(CoseError::UnsupportedError(
+                            "Unsupported hashing algorithm".into(),
+                        ))
+                    }
+                };
+                let (sig_alg, correct_hash_alg, key_length) = match parameters.ecc_curve() {
+                    tss_esapi::interface_types::ecc::EccCurve::NistP256 => (
+                        SignatureAlgorithm::ES256,
+                        tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256,
+                        32,
+                    ),
+                    tss_esapi::interface_types::ecc::EccCurve::NistP384 => (
+                        SignatureAlgorithm::ES384,
+                        tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha384,
+                        48,
+                    ),
+                    tss_esapi::interface_types::ecc::EccCurve::NistP521 => (
+                        SignatureAlgorithm::ES512,
+                        tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha512,
+                        66,
+                    ),
+                    _ => {
+                        return Err(CoseError::UnsupportedError(
+                            "Unsupported ECC curve used".into(),
+                        ))
+                    }
+                };
+                if hash_alg != correct_hash_alg {
+                    return Err(CoseError::SpecificationError(
+                        "Invalid hash algorithm".into(),
+                    ));
+                }
+                Ok(((sig_alg, param_hash_alg), hash_alg, key_length))
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl aws_nitro_enclaves_cose::crypto::SigningPublicKey for TpmCoseSigner {
+    fn get_parameters(
+        &self,
+    ) -> Result<
+        (
+            aws_nitro_enclaves_cose::sign::SignatureAlgorithm,
+            openssl::hash::MessageDigest,
+        ),
+        CoseError,
+    > {
+        Ok(TpmCoseSigner::public_to_parameters(&self.signing_public)?.0)
+    }
+
+    fn verify(&self, _digest: &[u8], _signature: &[u8]) -> Result<bool, CoseError> {
+        // In a Device Credential, we don't care about verifying signatures with the TPM
+        unimplemented!()
+    }
+}
+
+fn merge_ec_signature(bytes_r: &[u8], bytes_s: &[u8], key_length: usize) -> Vec<u8> {
+    assert!(bytes_r.len() <= key_length);
+    assert!(bytes_s.len() <= key_length);
+
+    let mut signature_bytes = vec![0u8; key_length * 2];
+
+    // This is big-endian encoding so padding might be added at the start if the factor is
+    // too short.
+    let offset_copy = key_length - bytes_r.len();
+    signature_bytes[offset_copy..offset_copy + bytes_r.len()].copy_from_slice(bytes_r);
+
+    // This is big-endian encoding so padding might be added at the start if the factor is
+    // too short.
+    let offset_copy = key_length - bytes_s.len() + key_length;
+    signature_bytes[offset_copy..offset_copy + bytes_s.len()].copy_from_slice(bytes_s);
+
+    signature_bytes
+}
+
+impl aws_nitro_enclaves_cose::crypto::SigningPrivateKey for TpmCoseSigner {
+    fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError> {
+        let key_length = Self::public_to_parameters(&self.signing_public)?.2;
+        let validation = tss_esapi::tss2_esys::TPMT_TK_HASHCHECK {
+            tag: tss_esapi::constants::tss::TPM2_ST_HASHCHECK,
+            hierarchy: tss_esapi::constants::tss::TPM2_RH_NULL,
+            digest: Default::default(),
+        }
+        .try_into()
+        .map_err(|_| {
+            CoseError::UnsupportedError("Error converting TPMT_TK_HASHCHECK".to_string())
+        })?;
+        let data = tss_esapi::structures::Digest::try_from(digest).map_err(|_| {
+            CoseError::UnsupportedError("Invalid data signing attempted".to_string())
+        })?;
+
+        // Special scope to not leak the context
+        let signature = {
+            let mut ctx = self.tss_context.borrow_mut();
+            ctx.execute_with_nullauth_session(|ctx| {
+                ctx.sign(
+                    self.signing_handle,
+                    data,
+                    tss_esapi::structures::SignatureScheme::Null,
+                    validation,
+                )
+            })
+            .map_err(|e| CoseError::UnsupportedError(format!("Error signing: {}", e)))?
+        };
+        match signature {
+            tss_esapi::structures::Signature::EcDsa(signature) => Ok(merge_ec_signature(
+                signature.signature_r().value(),
+                signature.signature_s().value(),
+                key_length,
+            )),
+            _ => Err(CoseError::UnsupportedError(
+                "Invalid signature type".to_string(),
+            )),
+        }
     }
 }

--- a/data-formats/src/devicecredential/mod.rs
+++ b/data-formats/src/devicecredential/mod.rs
@@ -18,5 +18,5 @@ pub trait DeviceCredential: std::fmt::Debug {
     ) -> Result<Box<dyn aws_nitro_enclaves_cose::crypto::SigningPrivateKey>, Error>;
 }
 
-mod file;
+pub mod file;
 pub use crate::devicecredential::file::FileDeviceCredential;

--- a/data-formats/src/errors.rs
+++ b/data-formats/src/errors.rs
@@ -69,4 +69,6 @@ pub enum Error {
     AddrError(#[from] std::net::AddrParseError),
     #[error("Unsupported version structure encountered. Version: {0:?}")]
     UnsupportedVersion(Option<crate::constants::ProtocolVersion>),
+    #[error("TPM/TSS error: {0:?}")]
+    TssError(#[from] tss_esapi::Error),
 }

--- a/integration-tests/templates/manufacturing-server.yml.j2
+++ b/integration-tests/templates/manufacturing-server.yml.j2
@@ -2,7 +2,7 @@
 session_store_driver: Directory
 session_store_config: {{ config_dir }}/sessions/
 ownership_voucher_store_driver: Directory
-ownership_voucher_store_config: {{ config_dir }}/ownership_vouchers/
+ownership_voucher_store_config: {{ test_dir }}/ownership_vouchers/
 bind: {{ bind }}
 rendezvous_info:
 - dns: localhost
@@ -21,8 +21,7 @@ protocols:
     key_type: SECP256R1
     mfg_string_type: SerialNumber
     allowed_key_storage_types:
-    - FileSystem
-    - Tpm
+    - {{ diun_key_type }}
 manufacturing:
   manufacturer_cert_path: {{ keys_path }}/manufacturer_cert.pem
   manufacturer_private_key: {{ keys_path }}/manufacturer_key.der

--- a/integration-tests/templates/owner-onboarding-server.yml.j2
+++ b/integration-tests/templates/owner-onboarding-server.yml.j2
@@ -2,7 +2,7 @@
 session_store_driver: Directory
 session_store_config: {{ config_dir }}/sessions/
 ownership_voucher_store_driver: Directory
-ownership_voucher_store_config: {{ config_dir }}/ownership_vouchers/
+ownership_voucher_store_config: {{ test_dir }}/ownership_vouchers/
 trusted_device_keys_path: {{ keys_path }}/device_ca_cert.pem
 owner_private_key_path: {{ keys_path }}/owner_key.der
 owner_public_key_path: {{ keys_path }}/owner_cert.pem

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -739,8 +739,8 @@ impl<'a> TestServerConfigurator<'a> {
                     "bind",
                     &format!("127.0.0.1:{}", self.server_number.server_port().unwrap()),
                 );
+                cfg.insert("test_dir", &self.test_context.testpath());
                 cfg.insert("owner_port", &self.server_number.server_port().unwrap());
-                cfg.insert("rendezvous_port", &1337);
                 cfg.insert(
                     "config_dir",
                     &self.test_context.runner_path(&self.server_number),

--- a/integration-tests/tests/di_diun.rs
+++ b/integration-tests/tests/di_diun.rs
@@ -3,154 +3,9 @@ use std::time::Duration;
 
 use common::{Binary, LogSide, TestContext};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 const L: LogSide = LogSide::Test;
-
-#[tokio::test]
-async fn test_diun() -> Result<()> {
-    let verification_methods: &[(
-        &'static str,
-        Box<dyn Fn(&TestContext) -> Result<(&'static str, String, &'static str)>>,
-    )] = &[
-        (
-            "insecure",
-            Box::new(|_| {
-                Ok((
-                    "DIUN_PUB_KEY_INSECURE",
-                    "true".to_string(),
-                    "Trusting any certificate as root",
-                ))
-            }),
-        ),
-        (
-            "hash",
-            Box::new(|ctx| {
-                let diun_cert = std::fs::read(ctx.keys_path().join("diun_cert.pem"))?;
-                let diun_cert = openssl::x509::X509::from_pem(&diun_cert)?;
-                let diun_cert_hash = diun_cert.digest(openssl::hash::MessageDigest::sha256())?;
-                Ok((
-                    "DIUN_PUB_KEY_HASH",
-                    format!("sha256:{}", hex::encode(&diun_cert_hash)),
-                    "Checking digest",
-                ))
-            }),
-        ),
-        (
-            "rootcert",
-            Box::new(|ctx| {
-                Ok((
-                    "DIUN_PUB_KEY_ROOTCERTS",
-                    ctx.keys_path()
-                        .join("diun_cert.pem")
-                        .to_string_lossy()
-                        .to_string(),
-                    "Checking for cert",
-                ))
-            }),
-        ),
-    ];
-
-    for (verification_method_name, verification_method_generator) in verification_methods {
-        test_diun_impl(verification_method_generator)
-            .await
-            .context(format!("{} verification method", verification_method_name))?;
-    }
-
-    Ok(())
-}
-
-async fn test_diun_impl<F>(verification_generator: F) -> Result<()>
-where
-    F: Fn(&TestContext) -> Result<(&'static str, String, &'static str)>,
-{
-    let mut ctx = TestContext::new().context("Error building test context")?;
-
-    let mfg_server = ctx
-        .start_test_server(
-            Binary::ManufacturingServer,
-            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
-            |_| Ok(()),
-        )
-        .context("Error creating manufacturing server")?;
-    ctx.wait_until_servers_ready()
-        .await
-        .context("Error waiting for servers to start")?;
-
-    let (verification_key, verification_value, verification_searchstr) =
-        verification_generator(&ctx).context("Error generating verification information")?;
-
-    let client_result = ctx
-        .run_client(
-            Binary::ManufacturingClient,
-            Some(&mfg_server),
-            |cfg| {
-                cfg.env("DEVICE_CREDENTIAL_FILENAME", "devicecredential.dc")
-                    .env("MANUFACTURING_INFO", "testdevice")
-                    .env(&verification_key, &verification_value);
-                Ok(())
-            },
-            Duration::from_secs(5),
-        )
-        .context("Error running manufacturing client")?;
-    client_result
-        .expect_success()
-        .context("Manufacturing client failed")?;
-    client_result.expect_stderr_line(verification_searchstr)?;
-
-    let dc_path = client_result.client_path().join("devicecredential.dc");
-    L.l(format!("Device Credential should be in {:?}", dc_path));
-
-    let owner_output = ctx
-        .run_owner_tool(
-            client_result.client_path(),
-            &["dump-device-credential", dc_path.to_str().unwrap()],
-        )
-        .context("Error running dump-device-credential")?;
-    owner_output
-        .expect_success()
-        .context("Dump-device-credential failed")?;
-    owner_output.expect_stdout_line("Active: true")?;
-
-    let ov_dir = ctx
-        .testpath()
-        .join(mfg_server.name())
-        .join("ownership_vouchers");
-    let mut ov_files =
-        std::fs::read_dir(ov_dir).context("Error reading ownership voucher directory")?;
-    L.l(format!("Ownership Voucher files: {:?}", &ov_files));
-    let ov_file = ov_files.next();
-    if ov_file.is_none() {
-        bail!("No ownership voucher files found");
-    }
-    let ov_file = ov_file
-        .unwrap()
-        .context("Error reading OV file directory")?;
-    let num_count = ov_files.count() + 1; // The +1 is because we consumed the first item
-    if num_count != 1 {
-        bail!(
-            "Invalid number of ownership vouchers: {}, expected 1",
-            num_count
-        );
-    }
-    L.l(format!("Ownership voucher path: {:?}", ov_file));
-
-    let owner_output = ctx
-        .run_owner_tool(
-            client_result.client_path(),
-            &["dump-ownership-voucher", ov_file.path().to_str().unwrap()],
-        )
-        .context("Error running dump-ownership-voucher")?;
-    owner_output
-        .expect_success()
-        .context("Dump-ownership-voucher failed")?;
-    owner_output.expect_stdout_line("Device Info: \"testdevice\"")?;
-    owner_output.expect_stdout_line("commonName = \"testdevice\"")?;
-    // It should have been extended to the "owner" time by the manufacturer
-    owner_output.expect_stdout_line("Entry 0")?;
-
-    Ok(())
-}
 
 #[tokio::test]
 async fn test_device_credentials_already_active() -> Result<()> {
@@ -159,7 +14,13 @@ async fn test_device_credentials_already_active() -> Result<()> {
     let mfg_server = ctx
         .start_test_server(
             Binary::ManufacturingServer,
-            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |cfg| {
+                Ok(cfg.prepare_config_file(None, |cfg| {
+                    cfg.insert("rendezvous_port", "1337");
+                    cfg.insert("diun_key_type", "FileSystem");
+                    Ok(())
+                })?)
+            },
             |_| Ok(()),
         )
         .context("Error creating manufacturing server")?;

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -1,0 +1,275 @@
+mod common;
+use std::{fs, time::Duration};
+
+use common::{Binary, LogSide, TestContext};
+
+use anyhow::{bail, Context, Result};
+
+const L: LogSide = LogSide::Test;
+
+#[tokio::test]
+async fn test_e2e() -> Result<()> {
+    let diun_verification_methods: &[(
+        &'static str,
+        Box<dyn Fn(&TestContext) -> Result<(&'static str, String, &'static str)>>,
+    )] = &[
+        (
+            "insecure",
+            Box::new(|_| {
+                Ok((
+                    "DIUN_PUB_KEY_INSECURE",
+                    "true".to_string(),
+                    "Trusting any certificate as root",
+                ))
+            }),
+        ),
+        (
+            "hash",
+            Box::new(|ctx| {
+                let diun_cert = std::fs::read(ctx.keys_path().join("diun_cert.pem"))?;
+                let diun_cert = openssl::x509::X509::from_pem(&diun_cert)?;
+                let diun_cert_hash = diun_cert.digest(openssl::hash::MessageDigest::sha256())?;
+                Ok((
+                    "DIUN_PUB_KEY_HASH",
+                    format!("sha256:{}", hex::encode(&diun_cert_hash)),
+                    "Checking digest",
+                ))
+            }),
+        ),
+        (
+            "rootcert",
+            Box::new(|ctx| {
+                Ok((
+                    "DIUN_PUB_KEY_ROOTCERTS",
+                    ctx.keys_path()
+                        .join("diun_cert.pem")
+                        .to_string_lossy()
+                        .to_string(),
+                    "Checking for cert",
+                ))
+            }),
+        ),
+    ];
+    let mut diun_key_types = vec!["FileSystem"];
+    if std::fs::metadata("/dev/tpm0").is_ok() {
+        diun_key_types.push("Tpm");
+    }
+
+    let mut failed = Vec::new();
+
+    for (diun_verification_method_name, diun_verification_method_generator) in
+        diun_verification_methods
+    {
+        for diun_key_type in &diun_key_types {
+            match test_e2e_impl(diun_verification_method_generator, diun_key_type).await {
+                Ok(()) => (),
+                Err(e) => {
+                    failed.push(TestCase {
+                        diun_verification_method_name: diun_verification_method_name,
+                        diun_key_type: diun_key_type,
+                        error: e,
+                    });
+                }
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        for failed_case in failed {
+            eprintln!("Failed test: {:?}", failed_case);
+        }
+        bail!("Some tests failed");
+    }
+}
+
+#[derive(Debug)]
+struct TestCase {
+    #[allow(dead_code)]
+    diun_verification_method_name: &'static str,
+    #[allow(dead_code)]
+    diun_key_type: &'static str,
+    #[allow(dead_code)]
+    error: anyhow::Error,
+}
+
+async fn test_e2e_impl<F>(verification_generator: F, diun_key_type: &str) -> Result<()>
+where
+    F: Fn(&TestContext) -> Result<(&'static str, String, &'static str)>,
+{
+    let mut ctx = TestContext::new().context("Error building test context")?;
+
+    let rendezvous_server = ctx
+        .start_test_server(
+            Binary::RendezvousServer,
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |_| Ok(()),
+        )
+        .context("Error creating rendezvous server")?;
+    let owner_onboarding_server = ctx
+        .start_test_server(
+            Binary::OwnerOnboardingServer,
+            |cfg| Ok(cfg.prepare_config_file(None, |_| Ok(()))?),
+            |cmd| {
+                cmd.env("ALLOW_NONINTEROPERABLE_KDF", &"1");
+                Ok(())
+            },
+        )
+        .context("Error creating owner server")?;
+    let mfg_server = ctx
+        .start_test_server(
+            Binary::ManufacturingServer,
+            |cfg| {
+                Ok(cfg.prepare_config_file(None, |cfg| {
+                    cfg.insert("diun_key_type", diun_key_type);
+                    cfg.insert("rendezvous_port", &rendezvous_server.server_port().unwrap());
+                    Ok(())
+                })?)
+            },
+            |_| Ok(()),
+        )
+        .context("Error creating manufacturing server")?;
+    ctx.wait_until_servers_ready()
+        .await
+        .context("Error waiting for servers to start")?;
+
+    let (verification_key, verification_value, verification_searchstr) =
+        verification_generator(&ctx).context("Error generating verification information")?;
+
+    // Execute the DI(UN) protocols
+    let client_result = ctx
+        .run_client(
+            Binary::ManufacturingClient,
+            Some(&mfg_server),
+            |cfg| {
+                cfg.env("DEVICE_CREDENTIAL_FILENAME", "devicecredential.dc")
+                    .env("MANUFACTURING_INFO", "testdevice")
+                    .env(&verification_key, &verification_value);
+                Ok(())
+            },
+            Duration::from_secs(5),
+        )
+        .context("Error running manufacturing client")?;
+    client_result
+        .expect_success()
+        .context("Manufacturing client failed")?;
+    client_result.expect_stderr_line(verification_searchstr)?;
+
+    // Execute some tests on the device credential and ownership voucher
+    let dc_path = client_result.client_path().join("devicecredential.dc");
+    L.l(format!("Device Credential should be in {:?}", dc_path));
+
+    let owner_output = ctx
+        .run_owner_tool(
+            client_result.client_path(),
+            &["dump-device-credential", dc_path.to_str().unwrap()],
+        )
+        .context("Error running dump-device-credential")?;
+    owner_output
+        .expect_success()
+        .context("Dump-device-credential failed")?;
+    owner_output.expect_stdout_line("Active: true")?;
+    match diun_key_type {
+        "Tpm" => {
+            owner_output.expect_stdout_line("HMAC key TPM public: KeyedHash")?;
+            owner_output.expect_stdout_line("Signing key TPM public: Ecc")?;
+        }
+        "FileSystem" => {
+            owner_output.expect_stdout_line("HMAC key: <secret>")?;
+            owner_output.expect_stdout_line("Signing key: <secret>")?;
+        }
+        _ => bail!("Unknown DIUN key type: {}", diun_key_type),
+    }
+
+    let ov_dir = ctx.testpath().join("ownership_vouchers");
+    let mut ov_files =
+        std::fs::read_dir(ov_dir).context("Error reading ownership voucher directory")?;
+    L.l(format!("Ownership Voucher files: {:?}", &ov_files));
+    let ov_file = ov_files.next();
+    if ov_file.is_none() {
+        bail!("No ownership voucher files found");
+    }
+    let ov_file = ov_file
+        .unwrap()
+        .context("Error reading OV file directory")?;
+    let num_count = ov_files.count() + 1; // The +1 is because we consumed the first item
+    if num_count != 1 {
+        bail!(
+            "Invalid number of ownership vouchers: {}, expected 1",
+            num_count
+        );
+    }
+    L.l(format!("Ownership voucher path: {:?}", ov_file));
+
+    let owner_output = ctx
+        .run_owner_tool(
+            client_result.client_path(),
+            &["dump-ownership-voucher", ov_file.path().to_str().unwrap()],
+        )
+        .context("Error running dump-ownership-voucher")?;
+    owner_output
+        .expect_success()
+        .context("Dump-ownership-voucher failed")?;
+    owner_output.expect_stdout_line("Device Info: \"testdevice\"")?;
+    owner_output.expect_stdout_line("commonName = \"testdevice\"")?;
+    // It should have been extended to the "owner" time by the manufacturer
+    owner_output.expect_stdout_line("Entry 0")?;
+
+    // Ensure TO0 is executed
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "http://localhost:{}/report-to-rendezvous",
+            owner_onboarding_server.server_port().unwrap()
+        ))
+        .send()
+        .await?;
+    L.l(format!("Status code report-to-rendezvous {}", res.status()));
+
+    // Execute TO1/TO2 protocols
+    let ssh_authorized_keys_path = ctx.testpath().join("authorized_keys");
+    let marker_file_path = ctx.testpath().join("marker");
+    let binary_file_path_prefix = ctx.testpath().join("binary_files");
+
+    std::fs::create_dir(&binary_file_path_prefix).context("Error creating binary_files dir")?;
+
+    let output = ctx
+        .run_client(
+            Binary::ClientLinuxapp,
+            None,
+            |cfg| {
+                cfg.env("DEVICE_CREDENTIAL", dc_path.to_str().unwrap())
+                    .env("SSH_KEY_PATH", &ssh_authorized_keys_path.to_str().unwrap())
+                    .env(
+                        "BINARYFILE_PATH_PREFIX",
+                        binary_file_path_prefix.to_str().unwrap(),
+                    )
+                    .env(
+                        "DEVICE_ONBOARDING_EXECUTED_MARKER_FILE_PATH",
+                        &marker_file_path.to_str().unwrap(),
+                    )
+                    .env("ALLOW_NONINTEROPERABLE_KDF", &"1");
+                Ok(())
+            },
+            Duration::from_secs(5),
+        )
+        .context("Error running client")?;
+    output.expect_success().context("client failed")?;
+
+    pretty_assertions::assert_eq!(
+        fs::read_to_string(&marker_file_path).context("Error reading marker file")?,
+        "executed"
+    );
+    pretty_assertions::assert_eq!(
+        fs::read_to_string(&ssh_authorized_keys_path)
+            .context("Error reading authorized SSH keys")?,
+        "
+# These keys are installed by FIDO Device Onboarding
+testkey
+# End of FIDO Device Onboarding keys
+"
+    );
+
+    Ok(())
+}

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -115,10 +115,7 @@ async fn test_to() -> Result<()> {
         .to_string();
     L.l(format!("Device GUID: {:?}", device_guid));
 
-    let ov_to = ctx
-        .runner_path(&owner_onboarding_server)
-        .join("ownership_vouchers")
-        .join(&device_guid);
+    let ov_to = ctx.testpath().join("ownership_vouchers").join(&device_guid);
     L.l(format!(
         "Converting Ownership Voucher {:?}(pem) -> {:?}(cose)",
         ov_path, ov_to

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
 passwd = "0.0.1"
 rand = "0.8.4"
+tss-esapi = "7.0"
 
 fdo-data-formats = { path = "../data-formats", version = "0.3.0" }
 fdo-http-wrapper = { path = "../http-wrapper", version = "0.3.0", features = ["client"] }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -14,6 +14,7 @@ openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["full"] }
+tss-esapi = "7.0"
 
 fdo-util = { path = "../util", version = "0.3.0" }
 fdo-data-formats = { path = "../data-formats", version = "0.3.0" }


### PR DESCRIPTION
This implements a system where the keys for the device credential are
created by the TPM (never leaving the TPM), but the references to the
keys, and rendezvous info, etc, are stored on the filesystem.
This protects against having the actual private keys stolen when the
device credential file is extracted from a disk.

The current implementation only supports the ECDSA ciphers mentioned by
the FDO specification.

The current test suite does not set up a software TPM to execute the TPM
tests during CI, but it will execute the TPM tests if a TPM exists on
the system.

Fixes: #200
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>