### PR TITLE
feat: fall back to non-interoperable KDF

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -255,6 +255,10 @@ async fn perform_to2(
     let prove_ov_hdr = prove_ov_hdr.context("Error sending HelloDevice")?;
     let prove_ov_hdr = prove_ov_hdr.into_token();
 
+    let non_interoperable_kdf_required = client
+        .non_interoperable_kdf_required()
+        .ok_or_else(|| anyhow!("Error getting non-interoperable KDF requirement"))?;
+
     // NOTE: At this moment, we have not yet validated the signature on it...
     // We can only do so after we got all of the OV parts..
     let prove_ov_hdr_payload: UnverifiedValue<TO2ProveOVHdrPayload> = prove_ov_hdr
@@ -360,7 +364,12 @@ async fn perform_to2(
     let b_key_exchange =
         KeyExchange::new(kexsuite).context("Error creating device side of key exchange")?;
     let new_keys = b_key_exchange
-        .derive_key(KeyDeriveSide::Device, ciphersuite, a_key_exchange)
+        .derive_key(
+            KeyDeriveSide::Device,
+            ciphersuite,
+            a_key_exchange,
+            non_interoperable_kdf_required,
+        )
         .context("Error performing key derivation")?;
     let new_keys = fdo_http_wrapper::EncryptionKeys::from_derived(ciphersuite, new_keys);
 
@@ -464,7 +473,8 @@ async fn main() -> Result<()> {
     fdo_util::add_version!();
     fdo_http_wrapper::init_logging();
 
-    if !fdo_data_formats::INTEROPERABLE_KDF && std::env::var("ALLOW_NONINTEROPERABLE_KDF").is_err()
+    if !fdo_data_formats::interoperable_kdf_available()
+        && std::env::var("ALLOW_NONINTEROPERABLE_KDF").is_err()
     {
         bail!("Provide environment ALLOW_NONINTEROPERABLE_KDF=1 to enable interoperable KDF");
     }

--- a/data-formats/src/lib.rs
+++ b/data-formats/src/lib.rs
@@ -23,7 +23,18 @@ mod serializable;
 pub use serializable::DeserializableMany;
 pub use serializable::Serializable;
 
-#[cfg(feature = "use_noninteroperable_kdf")]
-pub const INTEROPERABLE_KDF: bool = false;
-#[cfg(not(feature = "use_noninteroperable_kdf"))]
-pub const INTEROPERABLE_KDF: bool = true;
+pub fn interoperable_kdf_available() -> bool {
+    #[cfg(feature = "use_noninteroperable_kdf")]
+    {
+        false
+    }
+    #[cfg(not(feature = "use_noninteroperable_kdf"))]
+    {
+        if std::env::var("FORCE_NONINTEROPERABLE_KDF").is_ok() {
+            log::warn!("Forcing the use of non-interoperable KDF via environment variable");
+            false
+        } else {
+            true
+        }
+    }
+}

--- a/manufacturing-client/src/main.rs
+++ b/manufacturing-client/src/main.rs
@@ -75,6 +75,10 @@ async fn perform_diun(
         .chain()
         .context("Error getting diun_pubkey: no chain")?;
 
+    let non_interoperable_kdf_required = client
+        .non_interoperable_kdf_required()
+        .ok_or_else(|| anyhow::anyhow!("Error getting non-interoperable KDF requirement"))?;
+
     let diun_pubkey = match pub_key_verification {
         DiunPublicKeyVerificationMode::Hash(hash) => diun_pubchain.verify_from_digest(&hash),
         DiunPublicKeyVerificationMode::Certs(bag) => diun_pubchain.verify_from_x5bag(&bag),
@@ -104,6 +108,7 @@ async fn perform_diun(
             KeyDeriveSide::Device,
             ciphersuite,
             accept_payload.key_exchange(),
+            non_interoperable_kdf_required,
         )
         .context("Error performing key derivation")?;
     let new_keys = EncryptionKeys::from_derived(ciphersuite, new_keys);

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -295,7 +295,8 @@ async fn main() -> Result<()> {
     fdo_util::add_version!();
     fdo_http_wrapper::init_logging();
 
-    if !fdo_data_formats::INTEROPERABLE_KDF && std::env::var("ALLOW_NONINTEROPERABLE_KDF").is_err()
+    if !fdo_data_formats::interoperable_kdf_available()
+        && std::env::var("ALLOW_NONINTEROPERABLE_KDF").is_err()
     {
         bail!("Provide environment ALLOW_NONINTEROPERABLE_KDF=1 to enable interoperable KDF");
     }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -11,7 +11,7 @@ pub fn maybe_print_version(
     let mut args = std::env::args();
     if args.len() == 2 && args.nth(1).unwrap() == "--version" {
         println!("{} {}.{}.{} {}", name, major, minor, patch, pre);
-        if !fdo_data_formats::INTEROPERABLE_KDF {
+        if !fdo_data_formats::interoperable_kdf_available() {
             println!("WARNING: This version of {} is not interoperable with FDO as it is using a non-interoperable KDF implementation",
                      name);
         }


### PR DESCRIPTION
This adds functionality to the client and server to gracefully fall back
to the non-interoperable KDF if the other side requires it.

Fixes: #227
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>