### PR TITLE
ci: do not crash commitlint on missing body

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -7,6 +7,7 @@ const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
   const { type, scope, body } = parsedCommit
   const isDepsCommit =
       type === 'chore'
+      && body != null
       && body.includes('Updates the requirements on');
 
   return [


### PR DESCRIPTION
This fixes a bug where commitlint fails to check if a commit is from
dependabot if it has no body at all.
It turns out that if a commit only has a header, the body becomes
`null`.
Let's make sure that that doesn't actually crash the check itself.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>