### PR TITLE
chore: port admin-tool to clap 3

### DIFF
--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 openssl = "0.10"
-clap = "2"
+clap = { version = "3.1", features = ["derive"] }
+


### PR DESCRIPTION
This ports the admin-tool ovcer to Clap 3, with the derive format.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>