### PR TITLE
chore: unify openssl-kdf versions in data-formats module

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -28,7 +28,7 @@ tss-esapi = "7.0"
 http = "0.2"
 hyper = "0.14"
 
-openssl-kdf = { version = "0.4", features = ["allow_custom"] }
+openssl-kdf = { version = "0.4.1", features = ["allow_custom"] }
 
 [features]
 # Whether to use a non-interoperable KDF.


### PR DESCRIPTION
There was two slightly different versions of openssl-kdf in the
Config.toml so unify them to make things consistent.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>