### PR TITLE
feat: add disk encryption to serviceinfo API server

### DIFF
--- a/admin-tool/src/aio/configure.rs
+++ b/admin-tool/src/aio/configure.rs
@@ -163,6 +163,7 @@ impl Configuration {
             initial_user: None,
             files: None,
             commands: None,
+            diskencryption_clevis: None,
             additional_serviceinfo: None,
         })
     }

--- a/integration-tests/templates/serviceinfo-api-server.yml.j2
+++ b/integration-tests/templates/serviceinfo-api-server.yml.j2
@@ -31,3 +31,11 @@ service_info:
   - command: touch
     args:
     - {{ keys_path }}/command-testfile
+{% if encrypted_disk_label %}
+  diskencryption_clevis:
+  - disk_label: {{ encrypted_disk_label }}
+    binding:
+      pin: test
+      config: "{}"
+    reencrypt: true
+{% endif %}

--- a/serviceinfo-api-server/src/main.rs
+++ b/serviceinfo-api-server/src/main.rs
@@ -290,6 +290,45 @@ async fn serviceinfo_handler(
         }
     }
 
+    if query_info
+        .modules
+        .contains(&FedoraIotServiceInfoModule::DiskEncryptionClevis.into())
+    {
+        if let Some(disk_encryptions) = &user_data
+            .service_info_configuration
+            .settings
+            .diskencryption_clevis
+        {
+            for encryption in disk_encryptions {
+                reply.add_extra(
+                    FedoraIotServiceInfoModule::DiskEncryptionClevis,
+                    "disk-label",
+                    &encryption.disk_label,
+                );
+                reply.add_extra(
+                    FedoraIotServiceInfoModule::DiskEncryptionClevis,
+                    "pin",
+                    &encryption.binding.pin,
+                );
+                reply.add_extra(
+                    FedoraIotServiceInfoModule::DiskEncryptionClevis,
+                    "config",
+                    &encryption.binding.config,
+                );
+                reply.add_extra(
+                    FedoraIotServiceInfoModule::DiskEncryptionClevis,
+                    "reencrypt",
+                    &encryption.reencrypt,
+                );
+                reply.add_extra(
+                    FedoraIotServiceInfoModule::DiskEncryptionClevis,
+                    "execute",
+                    &serde_json::Value::Null,
+                );
+            }
+        }
+    }
+
     if let Some(additional_serviceinfo) = &user_data
         .service_info_configuration
         .settings

--- a/util/src/servers/configuration/serviceinfo_api_server.rs
+++ b/util/src/servers/configuration/serviceinfo_api_server.rs
@@ -25,7 +25,22 @@ pub struct ServiceInfoSettings {
 
     pub commands: Option<Vec<ServiceInfoCommand>>,
 
+    pub diskencryption_clevis: Option<Vec<ServiceInfoDiskEncryptionClevis>>,
+
     pub additional_serviceinfo: Option<HashMap<ServiceInfoModule, Vec<(String, String)>>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ServiceInfoDiskEncryptionClevisBinding {
+    pub pin: String,
+    pub config: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ServiceInfoDiskEncryptionClevis {
+    pub disk_label: String,
+    pub binding: ServiceInfoDiskEncryptionClevisBinding,
+    pub reencrypt: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
This adds a simple configuration for the provided API server to return
clevis disk encryption.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>