### PR TITLE
ci: allow single reviewer if no actual stability impact

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,19 @@ pull_request_rules:
         method: merge
         rebase_fallback: none
 
+  - name: Automatic merge on approval (stability impact no impact)
+    conditions:
+    - base=main
+    - "#approved-reviews-by>=1"
+    - "label=possible stability impact"
+    - "label=stability impact assessed: no impact"
+    actions:
+      queue:
+        name: fido-device-onboard-rs
+        method: merge
+        rebase_fallback: none
+
+
   - name: Automatic merge on approval (stability impact)
     conditions:
     - base=main


### PR DESCRIPTION
Our "possible stability impact" labeler is very rudimentary, and
sometimes a patch does not actually impact stability.
When that happens, this label can be added and the PR can still go in
with a single reviewer.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>