### PR TITLE
feat: support AIO with bindir in /usr/libexec/fdo

### DIFF
--- a/admin-tool/src/aio/mod.rs
+++ b/admin-tool/src/aio/mod.rs
@@ -11,6 +11,7 @@ mod execute;
 
 const POSSIBLE_BINARY_PATHS: &[&str] = &[
     "/usr/bin",
+    "/usr/libexec/fdo",
     #[cfg(debug_assertions)]
     "./target/debug",
     #[cfg(debug_assertions)]


### PR DESCRIPTION
In some packages, the binaries are stored in /usr/libexec/fdo, so make
it automatically detect the binaries from there as well.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>