### PR TITLE
chore(examples): clarify paths again

### DIFF
--- a/examples/config/serviceinfo-api-server.yml
+++ b/examples/config/serviceinfo-api-server.yml
@@ -11,11 +11,11 @@ service_info:
     sshkeys:
     - "testkey"
   files:
-  - path: hosts
+  - path: /device/etc/hosts
     permissions: 644
-    source_path: /etc/hosts
-  - path: resolv.conf
-    source_path: /etc/resolv.conf
+    source_path: /server/local/etc/hosts
+  - path: /device/etc/resolv.conf
+    source_path: /server/local/etc/resolv.conf
   commands:
   - command: ls
     args:

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -36,6 +36,8 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: openssl-devel >= 3.0.1-12
 BuildRequires: golang
 BuildRequires: tpm2-tss-devel
+BuildRequires: cryptsetup-devel
+BuildRequires: clang-devel
 
 %description
 %{summary}.
@@ -154,6 +156,9 @@ Requires: openssl-libs >= 3.0.1-12
 %package -n fdo-client
 Summary: FDO Client implementation
 Requires: openssl-libs >= 3.0.1-12
+Requires: clevis
+Requires: clevis-luks
+Requires: cryptsetup
 %description -n fdo-client
 %{summary}
 


### PR DESCRIPTION
a similar change was dropped when the sim server was split from the
onboarding server. Put this back.

Signed-off-by: Antonio Murdaca <runcom@linux.com>