### PR TITLE
fix(client-linuxapp): refactor binary file in progress methods

### DIFF
--- a/data-formats/src/messages/mod.rs
+++ b/data-formats/src/messages/mod.rs
@@ -63,6 +63,7 @@ pub trait Message: Send + Serializable + Sized {
     }
 }
 
+#[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! simple_message_serializable {
     ($name:ident, $inner_type:ident) => {

--- a/integration-tests/templates/serviceinfo-api-server.yml.j2
+++ b/integration-tests/templates/serviceinfo-api-server.yml.j2
@@ -11,10 +11,10 @@ service_info:
     sshkeys:
     - "testkey"
   files:
-  - path: hosts
+  - path: /etc/hosts
     permissions: 644
     source_path: /etc/hosts
-  - path: resolv.conf
+  - path: /etc/resolv.conf
     source_path: /etc/resolv.conf
   commands:
   - command: ls

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -268,15 +268,15 @@ testkey
 "
     );
 
-    assert!(binary_file_path_prefix.join("resolv.conf").exists());
+    assert!(binary_file_path_prefix.join("etc/resolv.conf").exists());
     let resolv_conf_metadata = binary_file_path_prefix
-        .join("resolv.conf")
+        .join("etc/resolv.conf")
         .metadata()
         .context("Error reading hosts file")?;
     assert_eq!(resolv_conf_metadata.permissions().mode() & 0o777, 0o600);
-    assert!(binary_file_path_prefix.join("hosts").exists());
+    assert!(binary_file_path_prefix.join("etc/hosts").exists());
     let hosts_metadata = binary_file_path_prefix
-        .join("hosts")
+        .join("etc/hosts")
         .metadata()
         .context("Error reading hosts file")?;
     assert_eq!(hosts_metadata.permissions().mode() & 0o777, 0o644);

--- a/manufacturing-server/src/main.rs
+++ b/manufacturing-server/src/main.rs
@@ -333,8 +333,7 @@ async fn main() -> Result<()> {
         .1;
     let server = tokio::spawn(server);
 
-    #[allow(clippy::panic)]
-    let _ = tokio::select!(
+    tokio::select!(
     _ = server => {
         log::info!("Server terminated");
     },

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -445,8 +445,7 @@ async fn main() -> Result<()> {
         .1;
     let server = tokio::spawn(server);
 
-    #[allow(clippy::panic)]
-    let _ = tokio::select!(
+    tokio::select!(
     _ = server => {
         log::info!("Server terminated");
     },

--- a/rendezvous-server/src/main.rs
+++ b/rendezvous-server/src/main.rs
@@ -211,8 +211,7 @@ async fn main() -> Result<()> {
         .1;
     let server = tokio::spawn(server);
 
-    #[allow(clippy::panic)]
-    let _ = tokio::select!(
+    tokio::select!(
     _ = server => {
         log::info!("Server terminated");
     },


### PR DESCRIPTION
Also add some unit testing. What this does is basically:

- make sure the path we get is always absolute, and do not join it with
  the test variable before that check
- make sure paths are joined correctly in case there's a prefix from
  environment variables (mainly for testing)
- refactor the struct/methods to be easy to add some unit test to
  validate what we're writing
- also make sure we create the parents (mkdir -p) when writing a file (Fixes https://github.com/fedora-iot/fido-device-onboard-rs/issues/289)

Signed-off-by: Antonio Murdaca <runcom@linux.com>