### PR TITLE
fix (clientlinuxapp): Log ERROR when failing to install sshkey

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -1007,7 +1007,7 @@ async fn perform_to2(
 
     // Now, the magic: performing the roundtrip! We delegated that.
     if let Err(serviceinfo_err) = serviceinfo::perform_to2_serviceinfos(&mut client).await {
-        log::info!("ServiceInfo failed, error: {:?}", serviceinfo_err);
+        log::error!("ServiceInfo failed, error: {:?}", serviceinfo_err);
         let e_result = ErrorResult::new(
             ErrorCode::InternalServerError,
             "Error performing the ServiceInfo roundtrips",
@@ -1202,7 +1202,7 @@ async fn main() -> Result<()> {
                         break;
                     }
                     Err(e) => {
-                        log::trace!("{:?} with TO2 address {}", e, to2_address);
+                        log::error!("{:?} with TO2 address {}", e, to2_address);
                         continue;
                     }
                 }

--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -323,13 +323,6 @@ impl CommandInProgress {
         let mut cmd = Command::new(self.command.as_ref().unwrap());
         cmd.args(&self.args);
 
-        if !self.return_stdout {
-            cmd.stdout(std::process::Stdio::null());
-        }
-        if !self.return_stderr {
-            cmd.stderr(std::process::Stdio::null());
-        }
-
         let output = cmd.output().context("Error running command")?;
 
         if self.return_stdout {
@@ -355,7 +348,12 @@ impl CommandInProgress {
         if self.may_fail || output.status.success() {
             Ok(())
         } else {
-            bail!("Command failed")
+            bail!(
+                "Command failed {} {:?} stderr: {}",
+                self.command.as_ref().unwrap(),
+                self.args,
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
     }
 }


### PR DESCRIPTION
closes #202 
This PR contains fix for clientlinuxapp logging . When failing to install sshkey while performing fdo-onboarding , the errors were logged as 'TRACE' instead of 'ERROR' which makes it now easier for user to identify errors.
