### PR TITLE
Update example rendezvous-server.yml

### DIFF
--- a/examples/config/rendezvous-server.yml
+++ b/examples/config/rendezvous-server.yml
@@ -1,9 +1,10 @@
 ---
 storage_driver:
   Directory:
-    path: /path/to/rendezvous_registered/
-session_store_driver: Directory
-session_store_config: /path/to/sessions/
+    path: /path/to/stores/rendezvous_registered
+session_store_driver:
+  Directory:
+    path: /path/to/stores/rendezvous_sessions
 trusted_manufacturer_keys_path: /path/to/keys/manufacturer_cert.pem
-trusted_device_keys_path: /path/to/keys/device_ca_cert.pem
-bind: 0.0.0.0:8082
+max_wait_seconds: ~
+bind: "0.0.0.0:8082"


### PR DESCRIPTION
Update rendezvous-server.yml to include 'max_wait_seconds:' and updated storage path used in the AIO. This prevents a panic when trying to run the server without 'max_wait_seconds'.

This also removes the 'trusted_device_keys_path: /path/to/keys/device_ca_cert.pem', as it doesn't seem to be needed (not included in the config when running the fdo-aio). Please confirm before merging. 

Signed-off-by: Paul Whalen <pwhalen@redhat.com>