### PR TITLE
chore: add expected directories to dockerfiles

### DIFF
--- a/contrib/containers/README.md
+++ b/contrib/containers/README.md
@@ -8,6 +8,14 @@ containers.
  mkdir keys
  for i in "diun" "manufacturer" "device-ca" "owner"; do fdo-admin-tool generate-key-and-cert $i; done
 ```
+# Copy and edit the configuration files
+
+Copy the configuration file from the examples provided and edit as needed. 
+
+- [manufacturing-server.yml] (https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/config/manufacturing-server.yml)
+- [owner-onboarding-server.yml] (https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/config/owner-onboarding-server.yml)
+- [rendezvous-server.yml] (https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/config/owner-onboarding-server.yml)
+- [serviceinfo-api-server.yml] (https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/config/owner-onboarding-server.yml) 
 
 ## Running the FDO containers
 ### manufacturing-server 

--- a/contrib/containers/manufacturing-server
+++ b/contrib/containers/manufacturing-server
@@ -2,6 +2,7 @@ FROM quay.io/centos/centos:stream9
 ARG BUILDID
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-manufacturing-server /usr/local/bin
 RUN mkdir -p /etc/fdo/sessions
+RUN mkdir -p /etc/fdo/keys
 RUN mkdir -p /etc/fdo/manufacturing-server.conf.d
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-manufacturing-server"]

--- a/contrib/containers/owner-onboarding-server
+++ b/contrib/containers/owner-onboarding-server
@@ -2,6 +2,7 @@ FROM quay.io/centos/centos:stream9
 ARG BUILDID
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-owner-onboarding-server /usr/local/bin
 RUN mkdir -p /etc/fdo/sessions
+RUN mkdir -p /etc/fdo/keys
 RUN mkdir -p /etc/fdo/owner-onboarding-server.conf.d
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-owner-onboarding-server"]

--- a/contrib/containers/rendezvous-server
+++ b/contrib/containers/rendezvous-server
@@ -2,6 +2,7 @@ FROM quay.io/centos/centos:stream9
 ARG BUILDID
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-rendezvous-server /usr/local/bin
 RUN mkdir -p /etc/fdo/sessions
+RUN mkdir -p /etc/fdo/keys 
 RUN mkdir -p /etc/fdo/rendezvous-server.conf.d
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-rendezvous-server"]

--- a/contrib/containers/serviceinfo-api-server
+++ b/contrib/containers/serviceinfo-api-server
@@ -2,6 +2,7 @@ FROM quay.io/centos/centos:stream9
 ARG BUILDID
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-serviceinfo-api-server /usr/local/bin
 RUN mkdir -p /etc/fdo/sessions
+RUN mkdir -p /etc/fdo/device_specific_serviceinfo
 RUN mkdir -p /etc/fdo/serviceinfo-api-server.conf.d
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-serviceinfo-api-server"]


### PR DESCRIPTION
Add 'keys' directory to manufacturing, owner-onboarding and rendezvous dockerfiles.
Add 'device_specific_serviceinfo' to serviceinfo-api-server dockerfile.

Signed-off-by: Paul Whalen <pwhalen@redhat.com>