### PR TITLE
refactor: replace println-s with log::info

### DIFF
--- a/data-formats/src/ownershipvoucher.rs
+++ b/data-formats/src/ownershipvoucher.rs
@@ -405,8 +405,8 @@ impl<'a> EntryIter<'a> {
         match entry.hash_header_info.compare(&hdr_info_hash) {
             Ok(_) => {}
             Err(e) => {
-                println!("Header hash: {:?}", hdr_info_hash);
-                println!("Entry hash:  {:?}", entry.hash_header_info);
+                log::info!("Header hash: {:?}", hdr_info_hash);
+                log::info!("Entry hash:  {:?}", entry.hash_header_info);
                 log::error!("Error verifying header hash");
                 return Err(e);
             }


### PR DESCRIPTION
Replace some println!-s in favour of log::info.

Closes #55 
