### PR TITLE
fix: derive Eq on MessageType

### DIFF
--- a/data-formats/src/constants/mod.rs
+++ b/data-formats/src/constants/mod.rs
@@ -347,7 +347,7 @@ impl RendezvousProtocolValue {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, FromPrimitive, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, FromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum MessageType {


### PR DESCRIPTION
Two MessageTypes are the same if they have the same code, we can derive both Eq and PartialEq.

This fixes a Clippy warning that we were getting on CI.

Closes #315 