### PR TITLE
fix(fdo-clientlinuxapp): fix error log for clientlinuxapp

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -326,7 +326,7 @@ async fn get_to1d(
                 return Ok(to1);
             }
             Err(e) => {
-                log::trace!("{} with {:?}", e, client);
+                log::error!("{} with {:?}", e, client);
                 continue;
             }
         }
@@ -1143,7 +1143,7 @@ async fn main() -> Result<()> {
             let client_list = match get_client_list(rv_entry).await {
                 Ok(client_list) => client_list,
                 Err(e) => {
-                    log::trace!(
+                    log::error!(
                         "Error {:?} getting usable rendezvous client list from rv_entry {:?}",
                         e,
                         rv_entry
@@ -1157,7 +1157,7 @@ async fn main() -> Result<()> {
             let to1d = match to1d {
                 Ok(to1d) => to1d,
                 Err(e) => {
-                    log::trace!(
+                    log::error!(
                         "Error {:?} getting usable To1d from rv_entry {:?}",
                         e,
                         rv_entry


### PR DESCRIPTION
This PR contains:
- fix for #201 
-  - fix error log for fdo-clientlinuxapp in case of failing to contact
    rendezvous server.(e.g.wrong ip address)
    - earlier the error msg was displayed as TRACE instead of ERROR
    - no change in error message content.
    - Error msg:
    ERROR fdo_client_linuxapp  > Error performing TO1 with ServiceClient
    ERROR fdo_client_linuxapp  > Error Couldn't get TO1 from any Rendezvous
    server!getting usable To1d from rv_entry RendezvousInterpretedDirective