### PR TITLE
chore: bump libcryptsetup to 0.5.1

### DIFF
--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8.4"
 nix = "0.23.0"
 uuid = "1.0"
 thiserror = "1"
-libcryptsetup-rs = { version = "0.5.0", features = ["mutex"] }
+libcryptsetup-rs = { version = "0.5.1", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.32"
 


### PR DESCRIPTION
There's a build issue with newer versions of cryptsetup that needs a bugfix rust crate so bump from 0.5.0 to 0.5.1 to fix builds.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>