### PR TITLE
store: add metadata file support

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,6 +33,12 @@ pretty_assertions = "1.0.0"
 paste = "1.0"
 pem = "1.0"
 users = "0.11.0"
+time = "0.3"
 
 fdo-data-formats = { path = "../data-formats" }
 fdo-util = { path = "../util" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.5", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.5", features = ["directory"] }
+xattr = "0.2.3"
+    #xattr = { version = "0.2", default-features = false, optional = true }  # We *need* xattrs to store TTL
+

--- a/integration-tests/tests/store.rs
+++ b/integration-tests/tests/store.rs
@@ -1,0 +1,312 @@
+mod common;
+use anyhow::{Context, Result};
+use fdo_data_formats::{ownershipvoucher::OwnershipVoucher, types::Guid};
+use fdo_store::{
+    DirectoryStorageMode, FdoMetadata, MetadataLocalKey, Store, StoreError, FDO_METADATA_EX,
+};
+use fdo_util::servers::configuration::manufacturing_server::ManufacturingServerSettings;
+use fdo_util::servers::configuration::owner_onboarding_server::OwnerOnboardingServerSettings;
+use fdo_util::servers::{settings_for, OwnershipVoucherStoreMetadataKey};
+use std::fs::File;
+use std::path::PathBuf;
+use std::str::FromStr;
+use time;
+use xattr::FileExt;
+
+#[tokio::test]
+async fn test_00_initialize() -> Result<()> {
+    fdo_util::add_version!();
+    let settings: ManufacturingServerSettings = settings_for("test-manufacturing")?.try_into()?;
+    let _ov_store: Box<
+        dyn Store<
+            fdo_store::WriteOnlyOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings.ownership_voucher_store_driver.initialize()?;
+    let _ov_store2: Box<
+        dyn Store<
+            fdo_store::WriteOnlyOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings
+        .session_store_driver
+        .initialize_explicit_mode(DirectoryStorageMode::MetadataFile)?;
+    Ok(())
+}
+
+// based on impl MetadataValue for time::Duration, but tailored for us, and public
+fn to_stored_wrapper(duration: &time::Duration) -> Vec<u8> {
+    let ttl = time::OffsetDateTime::now_utc() + *duration;
+    i64::to_le_bytes(ttl.unix_timestamp()).into()
+}
+
+fn compare_vectors(v1: &Vec<u8>, v2: &Vec<u8>) -> bool {
+    (v1.len() == v2.len()) && v1.into_iter().zip(v2).all(|(a, b)| a.eq(b))
+}
+
+#[tokio::test]
+async fn test_01_store_metadata() -> Result<()> {
+    let settings: ManufacturingServerSettings = settings_for("test-manufacturing")?.try_into()?;
+    let ov_store: Box<
+        dyn Store<
+            fdo_store::ReadWriteOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings.ownership_voucher_store_driver.initialize()?;
+    // store contents
+    let wait_seconds = time::Duration::new(60 as i64, 0);
+    for path in std::fs::read_dir("vouchers/by-guid-pem")? {
+        let path = path?.path();
+        // skip metadata files, those are not OVs
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let voucher = OwnershipVoucher::from_pem(&std::fs::read(&path)?)?;
+        ov_store
+            .store_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Ttl,
+                &wait_seconds,
+            )
+            .await?;
+    }
+    // retrieve contents, check that they're the same
+    for path in std::fs::read_dir("vouchers/by-guid-pem")? {
+        let path = path?.path();
+        // skip .fdo-md files, those are not OVs
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let file = File::open(&path)?;
+        // The proper way to get this xattr is to use to_key, but it is private
+        // and we don't want to make that one public, so "store_ttl" is hardcored
+        match file.get_xattr(fdo_store::format_xattr("store_ttl")) {
+            Ok(Some(ttl)) => {
+                assert!(compare_vectors(&to_stored_wrapper(&wait_seconds), &ttl))
+            }
+            Ok(None) => assert!(false),
+            Err(_) => assert!(false),
+        };
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_01_store_metadata_metadata_mode() -> Result<()> {
+    let settings: ManufacturingServerSettings = settings_for("test-manufacturing")?.try_into()?;
+    let ov_store: Box<
+        dyn Store<
+            fdo_store::ReadWriteOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings
+        .ownership_voucher_store_driver
+        .initialize_explicit_mode(DirectoryStorageMode::MetadataFile)?;
+    let wait_seconds = time::Duration::new(60 as i64, 0);
+    for path in std::fs::read_dir("vouchers/by-guid-pem")? {
+        let path = path?.path();
+        // skip .fdo-md files, those are not OVs
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let voucher = OwnershipVoucher::from_pem(&std::fs::read(&path)?)?;
+        ov_store
+            .store_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Ttl,
+                &wait_seconds,
+            )
+            .await?;
+    }
+    for path in std::fs::read_dir("vouchers/by-guid-pem")? {
+        let path = path?.path();
+        // skip files that do not have .fdo-md extension
+        match path.as_path().extension() {
+            None => continue,
+            Some(ex) => {
+                if ex != FDO_METADATA_EX {
+                    continue;
+                }
+            }
+        };
+        let file = File::open(&path)?;
+        let metadata: FdoMetadata = serde_cbor::from_reader(&file)?;
+        let ttl = metadata.map.get("store_ttl").unwrap();
+        assert!(compare_vectors(&to_stored_wrapper(&wait_seconds), &ttl));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_02_load_data_metadata_mode() -> Result<()> {
+    // OVs need to be extended with the owner cert and in COSE format for this
+    // test
+    let settings: OwnerOnboardingServerSettings = settings_for("test-owner")?
+        .try_into()
+        .context("Error parsing config")?;
+    let ov_store: Box<
+        dyn Store<
+            fdo_store::ReadWriteOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings
+        .ownership_voucher_store_driver
+        .initialize_explicit_mode(DirectoryStorageMode::MetadataFile)?;
+
+    // store valid ttl metadata so that the OV is not discarded by the load_data
+    // method that we are going to test (which is also a valid thing to do)
+    let wait_seconds = time::Duration::new(600 as i64, 0);
+    for path in std::fs::read_dir("vouchers/by-guid-cose")? {
+        let path = path?.path();
+        // skip metadata
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let voucher = OwnershipVoucher::from_pem_or_raw(&std::fs::read(&path)?)?;
+        ov_store
+            .store_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Ttl,
+                &wait_seconds,
+            )
+            .await?;
+    }
+
+    for path in std::fs::read_dir("vouchers/by-guid-cose")? {
+        let path = path?.path();
+        // skip metadata files
+        match path.as_path().extension() {
+            Some(_) => continue,
+            None => (),
+        }
+        // try to load the OV
+        let guid = path.file_name().unwrap().to_str().unwrap();
+        let ov = ov_store.load_data(&Guid::from_str(guid).unwrap()).await?;
+        match ov {
+            Some(ov) => assert!(ov.num_entries() == 1),
+            None => (),
+        };
+    }
+    Ok(())
+}
+
+fn load_metadata(path: &PathBuf) -> Result<FdoMetadata, StoreError> {
+    let mut npath = path.to_owned();
+    if path.as_path().extension().is_none() {
+        npath = fdo_store::set_metadata_extension_to_path(path)?;
+    }
+    let file = match File::open(&npath) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(StoreError::Unspecified(format!(
+                "error on load_metadata {}",
+                e
+            )))
+        }
+    };
+    let metadata: FdoMetadata = match serde_cbor::from_reader(&file) {
+        Ok(data) => data,
+        Err(e) => {
+            return Err(StoreError::Unspecified(format!(
+                "Error deserialising data: {}",
+                e
+            )))
+        }
+    };
+    Ok(metadata)
+}
+
+#[tokio::test]
+async fn test_03_destroy_medatada_metadata_mode() -> Result<()> {
+    let settings: OwnerOnboardingServerSettings = settings_for("test-owner")?
+        .try_into()
+        .context("Error parsing config")?;
+    let ov_store: Box<
+        dyn Store<
+            fdo_store::ReadWriteOpen,
+            Guid,
+            OwnershipVoucher,
+            OwnershipVoucherStoreMetadataKey,
+        >,
+    > = settings
+        .ownership_voucher_store_driver
+        .initialize_explicit_mode(DirectoryStorageMode::MetadataFile)?;
+
+    // store valid metadata
+    let wait_seconds = time::Duration::new(123456, 0);
+    for path in std::fs::read_dir("vouchers/by-guid-cose")? {
+        let path = path?.path();
+        // skip metadata
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let voucher = OwnershipVoucher::from_pem_or_raw(&std::fs::read(&path)?)?;
+        ov_store
+            .store_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Local(OwnershipVoucherStoreMetadataKey::To2Performed),
+                &true,
+            )
+            .await?;
+        ov_store
+            .store_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Local(
+                    OwnershipVoucherStoreMetadataKey::To0AcceptOwnerWaitSeconds,
+                ),
+                &wait_seconds,
+            )
+            .await?;
+    }
+    // destroy the metadata, note that we are checking the removal of each key
+    // separately
+    for path in std::fs::read_dir("vouchers/by-guid-cose")? {
+        let path = path?.path();
+        // skip metadata files
+        match path.as_path().extension() {
+            Some(_) => continue,
+            _ => (),
+        };
+        let voucher = OwnershipVoucher::from_pem(&std::fs::read(&path)?)?;
+        ov_store
+            .destroy_metadata(
+                voucher.header().guid(),
+                &fdo_store::MetadataKey::Local(OwnershipVoucherStoreMetadataKey::To2Performed),
+            )
+            .await?;
+        let fdo_metadata = load_metadata(&path)?;
+        match fdo_metadata.map.get(
+            &fdo_store::MetadataKey::Local(OwnershipVoucherStoreMetadataKey::To2Performed)
+                .to_key()
+                .to_string(),
+        ) {
+            Some(_) => assert!(false),
+            None => assert!(true),
+        };
+        match fdo_metadata.map.get(
+            &fdo_store::MetadataKey::Local(OwnershipVoucherStoreMetadataKey::To0AcceptOwnerWaitSeconds)
+                .to_key()
+                .to_string(),
+        ) {
+            Some(_) => assert!(true),
+            None => assert!(false),
+        };
+    }
+
+    Ok(())
+}

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = "1"
 time = "0.3"
+regex = "1.6.0"
 
 # feature-specific dependencies
 # directory

--- a/store/src/directory.rs
+++ b/store/src/directory.rs
@@ -1,8 +1,12 @@
+use regex;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fs::{self, File};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::{self, FromStr};
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
@@ -10,8 +14,10 @@ use xattr::FileExt;
 
 use fdo_data_formats::Serializable;
 
-use crate::{FilterType, MetadataLocalKey, MetadataValue, ValueIter};
+use crate::{format_xattr, FdoMetadata, FilterType, MetadataLocalKey, MetadataValue, ValueIter};
+use crate::{set_metadata_extension_to_path, FDO_METADATA_EX};
 
+use super::DirectoryStorageMode;
 use super::Store;
 use super::StoreError;
 
@@ -43,11 +49,55 @@ where
         ))
     })?;
 
+    let xattr_support = check_xattr_support(&canonicalized_directory)?;
+
     Ok(Box::new(DirectoryStore {
         phantom_k: PhantomData,
         phantom_v: PhantomData,
 
         directory: canonicalized_directory,
+        xattr_enabled: xattr_support,
+    }))
+}
+
+pub(super) fn initialize_explicit_mode<OT, K, V, MKT>(
+    path: &Path,
+    mode: DirectoryStorageMode,
+) -> Result<Box<dyn Store<OT, K, V, MKT>>, StoreError>
+where
+    OT: crate::StoreOpenMode + 'static,
+    K: std::str::FromStr + std::string::ToString + Send + Sync + 'static,
+    V: Serializable + Send + Sync + Clone + 'static,
+    MKT: crate::MetadataLocalKey + 'static,
+{
+    if !path.is_absolute() {
+        return Err(StoreError::Configuration(
+            "Storage directory is not absolute".to_string(),
+        ));
+    }
+    fs::create_dir_all(path).map_err(|e| {
+        StoreError::Configuration(format!(
+            "Storage directory '{:?}' could not be created: {}",
+            path, e
+        ))
+    })?;
+
+    let canonicalized_directory = path.canonicalize().map_err(|e| {
+        StoreError::Configuration(format!(
+            "Storage directory '{:?}' could not be canonicalized: {}",
+            path, e
+        ))
+    })?;
+    let xattr_enabled = match mode {
+        DirectoryStorageMode::MetadataFile => false,
+        DirectoryStorageMode::Xattr => true,
+    };
+    Ok(Box::new(DirectoryStore {
+        phantom_k: PhantomData,
+        phantom_v: PhantomData,
+
+        directory: canonicalized_directory,
+        xattr_enabled,
     }))
 }
 
@@ -57,6 +107,7 @@ struct DirectoryStore<K, V> {
     phantom_v: PhantomData<V>,
 
     directory: PathBuf,
+    xattr_enabled: bool,
 }
 
 impl<K, V> DirectoryStore<K, V>
@@ -66,6 +117,101 @@ where
     fn get_path(&self, key: &K) -> PathBuf {
         self.directory.join(key.to_string().replace('/', "_slash_"))
     }
+}
+
+/// Filesystems supported by the linux kernel that also support extended attributes
+enum FileSystemXattrSupport {
+    Btrfs,
+    Ext2,
+    Ext3,
+    Ext4,
+    F2fs,
+    Lustre,
+    Jfs,
+    Ocfs2,
+    Orangefs,
+    Reiser4,
+    Reiserfs,
+    Squashfs,
+    Ubifs,
+    Xfs,
+    Yaffs2,
+    Zfs,
+}
+
+impl FromStr for FileSystemXattrSupport {
+    type Err = StoreError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "btrfs" => Ok(FileSystemXattrSupport::Btrfs),
+            "ext2" => Ok(FileSystemXattrSupport::Ext2),
+            "ext3" => Ok(FileSystemXattrSupport::Ext3),
+            "ext4" => Ok(FileSystemXattrSupport::Ext4),
+            "f2fs" => Ok(FileSystemXattrSupport::F2fs), // check
+            "lustre" => Ok(FileSystemXattrSupport::Lustre), // check
+            "jfs" => Ok(FileSystemXattrSupport::Jfs),
+            "ocfs2" => Ok(FileSystemXattrSupport::Ocfs2), // check
+            "orangefs" => Ok(FileSystemXattrSupport::Orangefs), // check
+            "reiser4" => Ok(FileSystemXattrSupport::Reiser4),
+            "reiser" => Ok(FileSystemXattrSupport::Reiserfs),
+            "squashfs" => Ok(FileSystemXattrSupport::Squashfs),
+            "ubifs" => Ok(FileSystemXattrSupport::Ubifs),
+            "xfs" => Ok(FileSystemXattrSupport::Xfs),
+            "yaffs2" => Ok(FileSystemXattrSupport::Yaffs2), // check
+            "zfs" => Ok(FileSystemXattrSupport::Zfs),
+            _ => Err(StoreError::Configuration(format!("Unsupported filesystem"))),
+        }
+    }
+}
+
+/// Checks whether the filesystem in the given path supports xattrs
+fn check_xattr_support(path: &Path) -> Result<bool, StoreError> {
+    let output = Command::new("df")
+        .arg("-T")
+        .arg(path)
+        .output()
+        .expect("command failed");
+    if !output.status.success() {
+        return Err(StoreError::Unspecified(format!(
+            "Couldn't initialize store"
+        )));
+    }
+    let result = String::from_utf8(output.stdout);
+    let mut result = match result {
+        Ok(result) => result,
+        Err(e) => {
+            return Err(StoreError::Unspecified(format!(
+                "Converting df output: {:?}",
+                e
+            )))
+        }
+    };
+    let pos = result.find("\n").expect("Parsing df output");
+    result.drain(..pos + 1);
+    let re =
+        regex::Regex::new(r"[\d[:alpha:]/]+[[:space:]]+([\d[:alpha:]]+).+").expect("Invalid regex");
+    let captures = re.captures(&result).unwrap();
+    let filesystem = match captures.get(1) {
+        None => return Err(StoreError::Unspecified(format!("Parsing df regex output"))),
+        Some(fs) => fs,
+    };
+    match FileSystemXattrSupport::from_str(&filesystem.as_str()) {
+        Ok(_) => {
+            log::trace!(
+                "'{}' filesystem type, xattr supported",
+                &filesystem.as_str()
+            );
+            return Ok(true);
+        }
+        Err(_) => {
+            log::trace!(
+                "'{}' filesystem type, xattr not supported",
+                &filesystem.as_str()
+            );
+            return Ok(false);
+        }
+    };
 }
 
 // TODO(runcom): fix this to use time::Duration and time
@@ -85,10 +231,7 @@ pub struct DirectoryStoreFilterType {
     directory: PathBuf,
     neqs: Vec<(String, Vec<u8>)>,
     lts: Vec<(String, i64)>,
-}
-
-fn format_xattr(key: &str) -> String {
-    format!("user.{}", key)
+    xattr_enabled: bool,
 }
 
 #[async_trait]
@@ -138,41 +281,126 @@ where
                 Ok(v) if v.is_file() => {}
                 Ok(_) => continue,
             }
+            // skip metadata files if xattr is not supported, we are iterating
+            // the files that have content but filtering based on metadata
+            if !self.xattr_enabled {
+                match path.as_path().extension() {
+                    None => (),
+                    Some(ex) => {
+                        if ex == FDO_METADATA_EX {
+                            continue;
+                        }
+                    }
+                }
+            }
             let mut neqs: HashSet<PathBuf> = HashSet::new();
             for neq in &self.neqs {
                 let (key, expected) = neq;
-                match xattr::get(path.clone(), format_xattr(key)) {
-                    Ok(Some(v)) => {
-                        let matching = expected.iter().zip(&v).filter(|&(a, b)| a == b).count();
-                        if expected.len() != matching {
+
+                if self.xattr_enabled {
+                    match xattr::get(path.clone(), format_xattr(key)) {
+                        Ok(Some(v)) => {
+                            let matching = expected.iter().zip(&v).filter(|&(a, b)| a == b).count();
+                            if expected.len() != matching {
+                                neqs.insert(path.clone());
+                            }
+                        }
+                        Ok(None) => {
                             neqs.insert(path.clone());
                         }
+                        Err(e) => {
+                            log::trace!("Error checking {}: {}", key, e.to_string());
+                            continue;
+                        }
                     }
-                    Ok(None) => {
-                        neqs.insert(path.clone());
-                    }
-                    Err(e) => {
-                        log::trace!("Error checking {}: {}", key, e.to_string());
-                        continue;
+                } else {
+                    let path_meta = set_metadata_extension_to_path(&path)?;
+                    let file = match File::open(&path_meta) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            return Err(StoreError::Unspecified(format!(
+                                "Couldn't open file (r): {}",
+                                e
+                            )))
+                        }
+                    };
+                    let metadata: FdoMetadata = match serde_cbor::from_reader(&file) {
+                        Ok(data) => data,
+                        Err(e) => {
+                            return Err(StoreError::Unspecified(format!(
+                                "Error deserialising data: {}",
+                                e
+                            )))
+                        }
+                    };
+                    // insert the path to the file with contents, not the path
+                    // to the associated metadata file
+                    match metadata.map.get(&format_xattr(key)) {
+                        Some(v) => {
+                            let matching = expected.iter().zip(v).filter(|&(a, b)| a == b).count();
+                            if expected.len() != matching {
+                                neqs.insert(path.clone());
+                            }
+                        }
+                        None => {
+                            neqs.insert(path.clone());
+                        }
                     }
                 }
             }
             for n in neqs {
                 for lt in &self.lts {
                     let (key, max) = lt;
-                    match xattr::get(n.clone(), format_xattr(key)) {
-                        Ok(Some(v)) => {
-                            let value = i64::from_le_bytes(v.try_into().unwrap());
-                            if value < *max {
+                    if self.xattr_enabled {
+                        match xattr::get(n.clone(), format_xattr(key)) {
+                            Ok(Some(v)) => {
+                                let value = i64::from_le_bytes(v.try_into().unwrap());
+                                if value < *max {
+                                    results.insert(n.clone());
+                                }
+                            }
+                            Ok(None) => {
                                 results.insert(n.clone());
                             }
+                            Err(e) => {
+                                log::trace!("Error checking {}: {}", key, e.to_string());
+                                continue;
+                            }
                         }
-                        Ok(None) => {
-                            results.insert(n.clone());
-                        }
-                        Err(e) => {
-                            log::trace!("Error checking {}: {}", key, e.to_string());
-                            continue;
+                    } else {
+                        // neqs holds paths fo files with data, not metadata,
+                        // we need to filter based on metadata
+                        let path_meta = set_metadata_extension_to_path(&n)?;
+                        let file = match File::open(&path_meta) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                return Err(StoreError::Unspecified(format!(
+                                    "Couldn't open file (r): {}",
+                                    e
+                                )))
+                            }
+                        };
+                        let metadata: FdoMetadata = match serde_cbor::from_reader(file) {
+                            Ok(data) => data,
+                            Err(e) => {
+                                return Err(StoreError::Unspecified(format!(
+                                    "Error deserialising data: {}",
+                                    e
+                                )))
+                            }
+                        };
+                        // if it has what we want insert 'n', the file with data
+                        match metadata.map.get(&format_xattr(key)) {
+                            Some(v) => {
+                                let v: &Vec<u8> = v;
+                                let value = i64::from_le_bytes(v.clone().try_into().unwrap());
+                                if value < *max {
+                                    results.insert(n.clone());
+                                }
+                            }
+                            None => {
+                                results.insert(n.clone());
+                            }
                         }
                     }
                 }
@@ -214,7 +442,9 @@ where
         log::trace!("Attempting to load data from {}", path.display());
 
         let file = match File::open(&path) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
             Err(e) => {
                 return Err(StoreError::Unspecified(format!(
                     "Error opening file: {}",
@@ -223,26 +453,76 @@ where
             }
             Ok(f) => f,
         };
-        match file.get_xattr(format_xattr(crate::MetadataKey::<MKT>::Ttl.to_key())) {
-            Ok(Some(ttl)) => {
-                let ttl = ttl_from_disk(&ttl)?;
-                if SystemTime::now() > ttl {
-                    log::trace!("Item has expired, attempting removal");
-                    if let Err(e) = fs::remove_file(&path) {
-                        log::info!("Error deleting expired file {}: {}", path.display(), e);
+        if self.xattr_enabled {
+            match file.get_xattr(format_xattr(crate::MetadataKey::<MKT>::Ttl.to_key())) {
+                Ok(Some(ttl)) => {
+                    let ttl = ttl_from_disk(&ttl)?;
+                    if SystemTime::now() > ttl {
+                        log::trace!("Item has expired, attempting removal");
+                        if let Err(e) = fs::remove_file(&path) {
+                            log::warn!("Error deleting expired file {}: {}", path.display(), e);
+                        }
+                        return Ok(None);
                     }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error checking TTL: {}",
+                        e
+                    )))
+                }
+            };
+        } else {
+            // We have two files, the file with the data (passed as a parameter)
+            // and the associated metadata file, which it's in the same path,
+            // and has the same name, but a different extension.
+            let path_meta = set_metadata_extension_to_path(&path)?;
+            let file_meta = match File::open(&path_meta) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Ok(None);
                 }
-            }
-            Ok(None) => {}
-            Err(e) => {
-                return Err(StoreError::Unspecified(format!(
-                    "Error checking TTL: {}",
-                    e
-                )))
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file: {}",
+                        e,
+                    )))
+                }
+                Ok(f) => f,
+            };
+            let metadata: FdoMetadata = match serde_cbor::from_reader(&file_meta) {
+                Ok(data) => data,
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error reading metadata from '{}': {}",
+                        path_meta.display(),
+                        e
+                    )))
+                }
+            };
+            let val = metadata.map.get(crate::MetadataKey::<MKT>::Ttl.to_key());
+            match val {
+                Some(ttl) => {
+                    let ttl = ttl_from_disk(&ttl)?;
+                    if SystemTime::now() > ttl {
+                        log::trace!("Item has expired, attempting removal");
+                        if let Err(e) = fs::remove_file(&path) {
+                            log::warn!("Error deleting expired file {}: {}", path.display(), e);
+                        }
+                        // also remove associated metadata file
+                        if let Err(e) = fs::remove_file(&path_meta) {
+                            log::warn!(
+                                "Error deleting associated metadata of expired file {}: {}",
+                                path_meta.display(),
+                                e
+                            );
+                        }
+                        return Ok(None);
+                    }
+                }
+                None => {}
             }
         }
-
         Ok(Some(V::deserialize_from_reader(&file).map_err(|e| {
             StoreError::Unspecified(format!("Error deserializing value: {:?}", e))
         })?))
@@ -256,30 +536,94 @@ where
     ) -> Result<(), StoreError> {
         let path = self.get_path(key);
         log::trace!("Attempting to load data from {}", path.display());
-
-        let file = match File::open(&path) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(e) => {
-                return Err(StoreError::Unspecified(format!(
-                    "Error opening file: {}",
-                    e,
-                )))
+        if self.xattr_enabled {
+            let file = match File::open(&path) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(());
+                }
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file: {}",
+                        e,
+                    )));
+                }
+                Ok(f) => f,
+            };
+            Ok(file
+                .set_xattr(
+                    format_xattr(metadata_key.to_key()),
+                    &metadata_value.to_stored()?,
+                )
+                .map_err(|e| {
+                    StoreError::Unspecified(format!(
+                        "Error creating xattr on {}: {:?}",
+                        path.display(),
+                        e
+                    ))
+                })?)
+        } else {
+            let path = set_metadata_extension_to_path(&path)?;
+            let (file, previous) = match File::open(&path) {
+                Ok(f) => (f, true),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => match File::create(&path) {
+                    Err(e) => {
+                        return Err(StoreError::Unspecified(format!(
+                            "Couldn't create file: {}",
+                            e
+                        )));
+                    }
+                    Ok(f) => (f, false),
+                },
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file (r): {}",
+                        e,
+                    )));
+                }
+            };
+            let mut metadata: FdoMetadata;
+            if previous {
+                metadata = match serde_cbor::from_reader(&file) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        return Err(StoreError::Unspecified(format!(
+                            "Error deserialising data: {}",
+                            e
+                        )))
+                    }
+                };
+                metadata.map.insert(
+                    metadata_key.to_key().to_string(),
+                    metadata_value.to_stored()?,
+                );
+            } else {
+                let mut hm = HashMap::new();
+                hm.insert(
+                    metadata_key.to_key().to_string(),
+                    metadata_value.to_stored()?,
+                );
+                metadata = FdoMetadata { map: hm };
             }
-            Ok(f) => f,
-        };
-
-        Ok(file
-            .set_xattr(
-                format_xattr(metadata_key.to_key()),
-                &metadata_value.to_stored()?,
-            )
-            .map_err(|e| {
-                StoreError::Unspecified(format!(
-                    "Error creating xattr on {}: {:?}",
-                    path.display(),
-                    e
-                ))
-            })?)
+            drop(file);
+            let file = match File::create(&path) {
+                Ok(f) => f,
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file (w): {}",
+                        e
+                    )))
+                }
+            };
+            match serde_cbor::to_writer(&file, &metadata) {
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error serializing data: {}",
+                        e
+                    )))
+                }
+                Ok(_) => Ok(()),
+            }
+        }
     }
 
     async fn destroy_metadata(
@@ -290,37 +634,87 @@ where
         let path = self.get_path(key);
         log::trace!("Attempting to load data from {}", path.display());
 
-        let file = match File::open(&path) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(e) => {
-                return Err(StoreError::Unspecified(format!(
-                    "Error opening file: {}",
-                    e,
-                )))
-            }
-            Ok(f) => f,
-        };
+        if self.xattr_enabled {
+            let file = match File::open(&path) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file: {}",
+                        e,
+                    )))
+                }
+                Ok(f) => f,
+            };
 
-        Ok(file
-            .remove_xattr(format_xattr(metadata_key.to_key()))
-            .map_err(|e| {
-                StoreError::Unspecified(format!(
-                    "Error removing xattr on {}: {:?}",
-                    path.display(),
-                    e
-                ))
-            })?)
+            Ok(file
+                .remove_xattr(format_xattr(metadata_key.to_key()))
+                .map_err(|e| {
+                    StoreError::Unspecified(format!(
+                        "Error removing xattr on {}: {:?}",
+                        path.display(),
+                        e
+                    ))
+                })?)
+        } else {
+            let path = set_metadata_extension_to_path(&path)?;
+            let file = match File::open(&path) {
+                Ok(f) => f,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file: {}",
+                        e
+                    )))
+                }
+            };
+            let mut metadata: FdoMetadata = match serde_cbor::from_reader(&file) {
+                Ok(data) => data,
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error deserialising data from '{}': {}",
+                        path.display(),
+                        e
+                    )))
+                }
+            };
+            drop(file);
+            metadata
+                .map
+                .remove_entry(&metadata_key.to_key().to_string());
+            let file = match File::create(&path) {
+                Ok(f) => f,
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error opening file (w): {}",
+                        e
+                    )))
+                }
+            };
+            match serde_cbor::to_writer(&file, &metadata) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error serializing data to '{}': {}",
+                        path.display(),
+                        e
+                    )))
+                }
+            }
+        }
     }
 
     async fn query_data(&self) -> crate::QueryResult<V, MKT> {
+        println!("On query_data (dir.rs)");
         Ok(Box::new(DirectoryStoreFilterType {
             directory: self.directory.clone(),
             neqs: Vec::new(),
             lts: Vec::new(),
+            xattr_enabled: self.xattr_enabled,
         }))
     }
 
     async fn store_data(&self, key: K, value: V) -> Result<(), StoreError> {
+        println!("On store_data (dir.rs)");
         let finalpath = self.get_path(&key);
         let mut path = finalpath.clone();
         path.set_file_name(format!(
@@ -351,15 +745,41 @@ where
     }
 
     async fn destroy_data(&self, key: &K) -> Result<(), StoreError> {
+        println!("On destroy_data (dir.rs)");
         let path = self.get_path(key);
         log::trace!("Attempting to delete data at {}", path.display());
 
-        fs::remove_file(&path).map_err(|e| {
-            StoreError::Unspecified(format!("Error removing '{}': {:?}", path.display(), e))
-        })
+        match fs::remove_file(&path) {
+            Ok(_) => (),
+            Err(e) => {
+                return Err(StoreError::Unspecified(format!(
+                    "Error removing '{}': {:?}",
+                    path.display(),
+                    e
+                )))
+            }
+        };
+        // also destroy associated metadata
+        if !self.xattr_enabled {
+            let path = set_metadata_extension_to_path(&path)?;
+            match fs::remove_file(&path) {
+                Ok(_) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(e) => {
+                    return Err(StoreError::Unspecified(format!(
+                        "Error removing associated metadata file '{}': {:?}",
+                        path.display(),
+                        e,
+                    )))
+                }
+            }
+        } else {
+            Ok(())
+        }
     }
 
     async fn perform_maintenance(&self) -> Result<(), StoreError> {
+        println!("On perform_maintenance (dir.rs)");
         let dir_entries = match fs::read_dir(&self.directory) {
             Err(e) => {
                 log::trace!(
@@ -392,21 +812,80 @@ where
                 Ok(v) if v.is_file() => {}
                 Ok(_) => continue,
             }
-            let ttl = match xattr::get(&path, format_xattr(crate::MetadataKey::<MKT>::Ttl.to_key()))
-            {
-                Err(e) => {
-                    log::trace!("Error looking up TTL xattr for {}: {:?}", path.display(), e);
+            // skip non-metadata files if xattr is not supported
+            if !self.xattr_enabled {
+                match path.as_path().extension() {
+                    None => continue,
+                    Some(ex) => {
+                        if ex != FDO_METADATA_EX {
+                            continue;
+                        }
+                    }
+                }
+                let path_meta = set_metadata_extension_to_path(&path)?;
+                let file_meta = match File::open(&path_meta) {
+                    Ok(f) => f,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => {
+                        log::trace!(
+                            "Error opening metadata file {}: {:?}",
+                            path_meta.display(),
+                            e
+                        );
+                        continue;
+                    }
+                };
+                let metadata: FdoMetadata = match serde_cbor::from_reader(&file_meta) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        return Err(StoreError::Unspecified(format!(
+                            "Error reading metadata from '{}': {:?}",
+                            path_meta.display(),
+                            e
+                        )))
+                    }
+                };
+                let val = metadata.map.get(crate::MetadataKey::<MKT>::Ttl.to_key());
+                match val {
+                    Some(ttl) => {
+                        if SystemTime::now() < ttl_from_disk(&ttl)? {
+                            continue;
+                        }
+                    }
+                    None => {
+                        continue;
+                    }
+                };
+                log::trace!("File at {} has expired, attempting removal", path.display());
+                if let Err(e) = fs::remove_file(&path) {
+                    log::warn!("Error deleting expired file {}: {}", path.display(), e);
+                }
+                if let Err(e) = fs::remove_file(&path_meta) {
+                    log::warn!(
+                        "Error deleting expired metadata file {}: {}",
+                        path_meta.display(),
+                        e
+                    );
+                }
+            } else {
+                let ttl = match xattr::get(
+                    &path,
+                    format_xattr(crate::MetadataKey::<MKT>::Ttl.to_key()),
+                ) {
+                    Err(e) => {
+                        log::trace!("Error looking up TTL xattr for {}: {:?}", path.display(), e);
+                        continue;
+                    }
+                    Ok(None) => continue,
+                    Ok(Some(val)) => ttl_from_disk(&val)?,
+                };
+                if SystemTime::now() < ttl {
                     continue;
                 }
-                Ok(None) => continue,
-                Ok(Some(val)) => ttl_from_disk(&val)?,
-            };
-            if SystemTime::now() < ttl {
-                continue;
-            }
-            log::trace!("File at {} has expired, attempting removal", path.display());
-            if let Err(e) = fs::remove_file(&path) {
-                log::info!("Error deleting expired file {}: {}", path.display(), e);
+                log::trace!("File at {} has expired, attempting removal", path.display());
+                if let Err(e) = fs::remove_file(&path) {
+                    log::info!("Error deleting expired file {}: {}", path.display(), e);
+                }
             }
         }
 


### PR DESCRIPTION
Adds metadata file support for systems that
do not support xattrs.

Integration tests for both the xattr storage
mode and the new metadata file storage mode.

Marked as draft because:
- [ ] I haven't added a test yet for every function of `DirectoryStore` and `DirectoryStoreFilterType`. Also the tests are both for the  xattr storage mode and the new metadata file storage mode.
- [ ] The tests need to feed on a standard config file, which I haven't parametrised yet
- [ ] I need to take another look at the code.
- [ ] CI might complain.

Signed-off-by: Irene Diez <idiez@redhat.com>