### PR TITLE
chore: bump reqwest to 0.11.9

### DIFF
--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -29,7 +29,7 @@ warp-sessions = { version = "1.0", optional = true }
 time = "0.3"
 
 # Client-side
-reqwest = { version = "0.11", optional = true, features = ["native-tls", "json"] }
+reqwest = { version = "0.11.9", optional = true, features = ["native-tls", "json"] }
 url = { version = "2", optional = true }
 
 [features]


### PR DESCRIPTION
There's a build issue with older versions of reqwest so bump to a release we know works.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>