### PR TITLE
chore: bump config crate to 0.13.2

### DIFF
--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+config = "0.13.2"
 openssl = "0.10.35"
 log = "0.4"
 time = "0.3.15"
 clap = { version = "3.1", features = ["derive"] }
-config = "0.11"
 futures = "0.3"
 reqwest = "0.11"
 tera = "1"

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-config = "0.11"
+config = "0.13.2"
 tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"

--- a/manufacturing-server/src/main.rs
+++ b/manufacturing-server/src/main.rs
@@ -171,7 +171,7 @@ async fn main() -> Result<()> {
     fdo_http_wrapper::init_logging();
 
     let settings: ManufacturingServerSettings = settings_for("manufacturing-server")?
-        .try_into()
+        .try_deserialize()
         .context("Error parsing configuration")?;
 
     // Bind information

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-config = "0.11"
+config = "0.13.2"
 tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"

--- a/owner-onboarding-server/src/main.rs
+++ b/owner-onboarding-server/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
     }
 
     let settings: OwnerOnboardingServerSettings = settings_for("owner-onboarding-server")?
-        .try_into()
+        .try_deserialize()
         .context("Error parsing configuration")?;
 
     // Bind information

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-config = "0.11"
+config = "0.13.2"
 tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"

--- a/rendezvous-server/src/main.rs
+++ b/rendezvous-server/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
     fdo_http_wrapper::init_logging();
 
     let settings: RendezvousServerSettings = settings_for("rendezvous-server")?
-        .try_into()
+        .try_deserialize()
         .context("Error parsing configuration")?;
 
     let max_wait_seconds = settings

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-config = "0.11"
+config = "0.13.2"
 hex = "0.4"
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"

--- a/serviceinfo-api-server/src/main.rs
+++ b/serviceinfo-api-server/src/main.rs
@@ -400,7 +400,7 @@ async fn main() -> Result<()> {
     fdo_http_wrapper::init_logging();
 
     let settings: ServiceInfoApiServerSettings = settings_for("serviceinfo-api-server")?
-        .try_into()
+        .try_deserialize()
         .context("Error parsing configuration")?;
 
     // Bind information

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 fdo-data-formats = { path = "../data-formats", version = "0.4.6" }
 
-config = "0.11"
+config = "0.13.2"
 futures = "0.3"
 thiserror = "1"
 async-trait = "0.1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-config = "0.11"
+config = "0.13.2"
 glob = "0.3.0"
 log = "0.4"
 serde = "1"


### PR DESCRIPTION
Bumps config crate to 0.13.2 and adds relevant changes due to deprecated methods.

Fixes #328 

Signed-off-by: Irene Diez <idiez@redhat.com>