### PR TITLE
chore: port owner-tool to clap v3.1

### DIFF
--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = "2"
+clap = { version = "3.1", features = ["derive"] }
 log = "0.4"
 openssl = "0.10.35"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Migrate `owner-tool` to clap v3.1, with the derive format.

Closes #327.