### PR TITLE
build: client-linuxapp: remove redurant openssl dependency

### DIFF
--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 log = "0.4"
-openssl = "0.10.35"
 tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
 serde_bytes = "0.11"


### PR DESCRIPTION
No need to directly specify openssl dependency here.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.com>