### PR TITLE
ci: remove deprecated option on mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,6 @@ pull_request_rules:
       queue:
         name: fido-device-onboard-rs
         method: merge
-        rebase_fallback: none
 
   - name: Automatic merge on approval (stability impact no impact)
     conditions:
@@ -26,7 +25,6 @@ pull_request_rules:
       queue:
         name: fido-device-onboard-rs
         method: merge
-        rebase_fallback: none
 
 
   - name: Automatic merge on approval (stability impact)
@@ -38,4 +36,3 @@ pull_request_rules:
       queue:
         name: fido-device-onboard-rs
         method: merge
-        rebase_fallback: none


### PR DESCRIPTION
`rebase_fallback` is deprecated, remove the option from the queue settings.

Closes #365 