### PR TITLE
fix: do not default to YAML !Tag syntax on serde_yaml serialization

### DIFF
--- a/util/src/servers/configuration/manufacturing_server.rs
+++ b/util/src/servers/configuration/manufacturing_server.rs
@@ -9,12 +9,15 @@ use super::{AbsolutePathBuf, Bind};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ManufacturingServerSettings {
     // Session store info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub session_store_driver: StoreConfig,
 
     // Ownership Voucher store info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub ownership_voucher_store_driver: StoreConfig,
 
     // Public key store info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub public_key_store_driver: Option<StoreConfig>,
 
     // Bind information

--- a/util/src/servers/configuration/owner_onboarding_server.rs
+++ b/util/src/servers/configuration/owner_onboarding_server.rs
@@ -7,9 +7,11 @@ use super::{AbsolutePathBuf, Bind};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OwnerOnboardingServerSettings {
     // Ownership Voucher storage info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub ownership_voucher_store_driver: StoreConfig,
 
     // Session store info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub session_store_driver: StoreConfig,
 
     // Trusted keys
@@ -24,6 +26,7 @@ pub struct OwnerOnboardingServerSettings {
 
     // Service Info API Server
     pub service_info_api_url: String,
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub service_info_api_authentication: fdo_http_wrapper::client::JsonAuthentication,
 
     pub owner_addresses: Vec<RemoteConnection>,

--- a/util/src/servers/configuration/rendezvous_server.rs
+++ b/util/src/servers/configuration/rendezvous_server.rs
@@ -6,9 +6,11 @@ use super::{AbsolutePathBuf, Bind};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RendezvousServerSettings {
     // Storage info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub storage_driver: StoreConfig,
 
     // Session store info
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub session_store_driver: StoreConfig,
 
     // Trusted keys

--- a/util/src/servers/configuration/serviceinfo_api_server.rs
+++ b/util/src/servers/configuration/serviceinfo_api_server.rs
@@ -14,6 +14,7 @@ pub struct ServiceInfoApiServerSettings {
     pub service_info_auth_token: String,
     pub admin_auth_token: Option<String>,
 
+    #[serde(with = "serde_yaml::with::singleton_map")]
     pub device_specific_store_driver: StoreConfig,
 }
 


### PR DESCRIPTION
Updating serde_yaml to 0.9 from 0.8 makes the serialization of enums based on the YAML Tag syntax instead of the previous JSON-style singleton map syntax. This breaks our deserialization since we expect JSON-style syntax.

Thereby, we explicitly declare that we need `serde_yaml::with::singleton_map` for our enums.

Fixes #374
