### PR TITLE
ci: add aio check step to the build_and_test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,13 @@ jobs:
           FDO_PRIVILEGED: true
         with:
           command: test
+      - name: Check aio
+        run: |
+          mkdir aio-dir/
+          ./target/debug/fdo-admin-tool aio --directory aio-dir/ &
+          AIO_PID=$!
+          sleep 5
+          if [ -d /proc/$AIO_PID ]; then rm -rf aio-dir; else exit 1; fi
       # This is primarily to ensure that changes to fdo_data.h are committed,
       # which is critical for determining whether any stability changes were made
       # during the PR review.


### PR DESCRIPTION
Adds an aio check step to the CI to ensure that the command can be run in order to prevent further errors like #374 