### PR TITLE
ci: replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   gofmt:
     name: Gofmt
@@ -80,11 +74,12 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
       - name: Install deps
         run: |
-          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel clippy cargo rust clevis cryptsetup-devel clang-devel
-      - uses: actions-rs/cargo@v1
+          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel clevis cryptsetup-devel clang-devel
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          command: clippy
-          args: -- -D warnings -D clippy::panic -D clippy::todo
+          toolchain: stable
+          components: clippy
+      - run: cargo clippy -- -D warnings -D clippy::panic -D clippy::todo
 
   build_and_test:
     runs-on: ubuntu-latest
@@ -92,7 +87,7 @@ jobs:
     steps:
       - name: Install deps
         run: |
-          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel swtpm swtpm-tools cargo rust git clevis clevis-luks cryptsetup cryptsetup-devel clang-devel cracklib-dicts
+          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel swtpm swtpm-tools git clevis clevis-luks cryptsetup cryptsetup-devel clang-devel cracklib-dicts
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
@@ -108,16 +103,15 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
-        uses: actions-rs/cargo@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          command: build
+          toolchain: stable
+      - name: Build
+        run: cargo build
       - name: Run tests
-        uses: actions-rs/cargo@v1
         env:
           FDO_PRIVILEGED: true
-        with:
-          command: test
+        run: cargo test
       - name: Check aio
         run: |
           mkdir aio-dir/


### PR DESCRIPTION
The organization `actions-rs` is unmaintained (see https://github.com/actions-rs/toolchain/issues/216). We are replacing the Github Actions that use it with `dtolnay/rust-toolchain`

Fixes #383 
