### PR TITLE
ci: update docker/metadata-action

### DIFF
--- a/.github/actions/build_containers/action.yml
+++ b/.github/actions/build_containers/action.yml
@@ -24,7 +24,7 @@ runs:
 
   - name: Container Metadata
     id: container-metadata
-    uses: docker/metadata-action@v3
+    uses: docker/metadata-action@v4
     with:
       images: "{0}"
       tags: |


### PR DESCRIPTION
This update removes the warnings showing in our CI due to Node.js 12 actions being deprecated.
