### PR TITLE
docs: fix typo in HOWTO.md

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -583,7 +583,7 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
 2. The client will look for the Device Credential created during the previous
   step. It will look for in on
   `/sys/firmware/qemu_fw_cfg/by_name/opt/device_onboarding/devicecredential/raw`,
-  in the location specified by the `DEVICE_CREDENCIAL` environment variable, or
+  in the location specified by the `DEVICE_CREDENTIAL` environment variable, or
   in `/etc/device-credentials`, in that order.
 
     ```bash


### PR DESCRIPTION
Fixes a typo in the `DEVICE_CREDENTIAL` env variable description.