### PR TITLE
Reboot option

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -464,6 +464,7 @@ service_info:
       pin: test
       config: "{}"
     reencrypt: true
+  after_onboarding_reboot: true
 ```
 
 Where:
@@ -502,6 +503,8 @@ Where:
           `{}`; sample configuration for `tpm2`: `'{"pcr_bank": "sha256",
           "prc_id": "1.7"}'`)
     - `reencrypt`: boolean, whether re-encryption should be done.
+  - `after_onboarding_reboot`: [OPTIONAL] specifies if the device should be
+    rebooted after onboarding has completed, boolean (default false).
   - `additional_service_info`: [OPTIONAL]
 
 ## How to run the servers

--- a/admin-tool/src/aio/configure.rs
+++ b/admin-tool/src/aio/configure.rs
@@ -166,6 +166,7 @@ impl Configuration {
             commands: None,
             diskencryption_clevis: None,
             additional_serviceinfo: None,
+            after_onboarding_reboot: Some(false),
         })
     }
 }

--- a/data-formats/src/constants/serviceinfo_names.rs
+++ b/data-formats/src/constants/serviceinfo_names.rs
@@ -53,6 +53,7 @@ impl FromStr for ServiceInfoModule {
             "org.fedoraiot.diskencryption-clevis" => {
                 FedoraIotServiceInfoModule::DiskEncryptionClevis.into()
             }
+            "org.fedoraiot.reboot" => FedoraIotServiceInfoModule::Reboot.into(),
 
             "com.redhat.subscriptionmanager" => {
                 RedHatComServiceInfoModule::SubscriptionManager.into()
@@ -125,6 +126,7 @@ pub enum FedoraIotServiceInfoModule {
     SSHKey,
     BinaryFile,
     DiskEncryptionClevis,
+    Reboot,
 }
 
 impl Display for FedoraIotServiceInfoModule {
@@ -137,6 +139,7 @@ impl Display for FedoraIotServiceInfoModule {
                 FedoraIotServiceInfoModule::SSHKey => "sshkey",
                 FedoraIotServiceInfoModule::BinaryFile => "binaryfile",
                 FedoraIotServiceInfoModule::DiskEncryptionClevis => "diskencryption-clevis",
+                FedoraIotServiceInfoModule::Reboot => "reboot",
             }
         )
     }

--- a/examples/config/serviceinfo-api-server.yml
+++ b/examples/config/serviceinfo-api-server.yml
@@ -37,3 +37,4 @@ service_info:
       pin: test
       config: "{}"
     reencrypt: true
+  after_onboarding_reboot: true

--- a/owner-onboarding-server/src/handlers.rs
+++ b/owner-onboarding-server/src/handlers.rs
@@ -560,6 +560,11 @@ async fn perform_service_info(
         }
     }
 
+    if let Some(reboot) = resp.reboot {
+        out_si.add(FedoraIotServiceInfoModule::Reboot, "active", &true)?;
+        out_si.add(FedoraIotServiceInfoModule::Reboot, "reboot", &reboot.reboot)?;
+    }
+
     log::trace!("Sending ServiceInfo result: {:?}", out_si);
 
     Ok(messages::v11::to2::OwnerServiceInfo::new(

--- a/serviceinfo-api-server/src/main.rs
+++ b/serviceinfo-api-server/src/main.rs
@@ -12,7 +12,7 @@ use fdo_data_formats::{
 use fdo_store::Store;
 use fdo_util::servers::{
     configuration::serviceinfo_api_server::{ServiceInfoApiServerSettings, ServiceInfoSettings},
-    settings_for, ServiceInfoApiReply, ServiceInfoApiReplyInitialUser,
+    settings_for, ServiceInfoApiReply, ServiceInfoApiReplyInitialUser, ServiceInfoApiReplyReboot,
 };
 
 #[derive(Debug)]
@@ -325,6 +325,21 @@ async fn serviceinfo_handler(
                     &serde_json::Value::Null,
                 );
             }
+        }
+    }
+
+    if query_info
+        .modules
+        .contains(&FedoraIotServiceInfoModule::Reboot.into())
+    {
+        if let Some(reboot) = &user_data
+            .service_info_configuration
+            .settings
+            .after_onboarding_reboot
+        {
+            reply.reply.reboot = Some(ServiceInfoApiReplyReboot {
+                reboot: reboot.to_owned(),
+            })
         }
     }
 

--- a/util/src/servers/configuration/serviceinfo_api_server.rs
+++ b/util/src/servers/configuration/serviceinfo_api_server.rs
@@ -29,6 +29,8 @@ pub struct ServiceInfoSettings {
     pub diskencryption_clevis: Option<Vec<ServiceInfoDiskEncryptionClevis>>,
 
     pub additional_serviceinfo: Option<HashMap<ServiceInfoModule, Vec<(String, String)>>>,
+
+    pub after_onboarding_reboot: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/util/src/servers/mod.rs
+++ b/util/src/servers/mod.rs
@@ -115,10 +115,17 @@ pub struct ServiceInfoApiReplyInitialUser {
     pub ssh_keys: Vec<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServiceInfoApiReplyReboot {
+    pub reboot: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ServiceInfoApiReply {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_user: Option<ServiceInfoApiReplyInitialUser>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_commands: Option<Vec<(ServiceInfoModule, String, serde_json::Value)>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reboot: Option<ServiceInfoApiReplyReboot>,
 }


### PR DESCRIPTION
This adds a new serviceinfo api module `reboot` which allows
to specify if the system should be rebooted after onboarding
is completed.

This means that no client errors can be sent back since onboarding
is already considered to be a success. This reboot action is
always handled last, so any other onboarding action may fail
and will be handled according to the protocol. Only if onboarding
is successfully handled the reboot action will take place.

This reboot action is optional and can be configured in the
`serviceinfo-api-server.yml`