### PR TITLE
fix: owner-onboarding service should also start serviceinfoapi service

### DIFF
--- a/examples/systemd/fdo-owner-onboarding-server.service
+++ b/examples/systemd/fdo-owner-onboarding-server.service
@@ -5,6 +5,7 @@ After=network-online.target
 [Service]
 Environment=LOG_LEVEL=info
 ExecStart=/usr/libexec/fdo/fdo-owner-onboarding-server
+ExecStartPost=/usr/libexec/fdo/fdo-serviceinfo-api-server
 # restart and failure condition
 
 [Install]


### PR DESCRIPTION
When using systemd units the `fdo-owner-onboarding-server.service` should also start `fdo-serviceinfo-api-server`.