### PR TITLE
chore: bump for 0.4.8 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -166,6 +166,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -215,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -247,9 +248,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cbindgen"
@@ -272,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cexpr"
@@ -387,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "3339b77607ffdf358f6b1146107785d6cdb2b3f251e1920e96c45a0fc08a7b18"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -533,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
+checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -545,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
+checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -560,15 +561,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
+checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
+checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,12 +611,12 @@ dependencies = [
 
 [[package]]
 name = "devicemapper-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2aad5bae6bc8a217f8c398c5737122966cbd35f19dd223433606225ec48285"
+checksum = "0178fe3c92cfbf6cd55ee2e2fd64df9f4136d6ba02d833f0be44b10b0dc8e918"
 dependencies = [
  "bindgen",
- "nix 0.24.3",
+ "nix 0.26.2",
 ]
 
 [[package]]
@@ -657,9 +658,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -726,19 +727,19 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "fdo-admin-tool"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.5",
  "config",
  "fdo-data-formats",
  "fdo-http-wrapper",
@@ -760,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-client-linuxapp"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "devicemapper",
@@ -782,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "assert-str",
  "cbindgen",
@@ -794,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data-formats"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "ciborium",
@@ -821,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-http-wrapper"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",
@@ -844,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-client"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "fdo-data-formats",
@@ -862,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-server"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "config",
@@ -882,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-onboarding-server"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "config",
@@ -905,10 +906,10 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-tool"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.5",
  "fdo-data-formats",
  "fdo-http-wrapper",
  "fdo-util",
@@ -923,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-rendezvous-server"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "config",
@@ -942,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "config",
@@ -961,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-store"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "config",
@@ -978,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-util"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "config",
@@ -1239,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1260,6 +1261,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -1441,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "fdo-data-formats",
@@ -1466,12 +1473,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1482,14 +1489,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1500,9 +1507,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1555,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "libcryptsetup-rs-sys"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af91b644699911c839309edbb8c8f6addd61e6b9553aa6d02ba71c37597afbe"
+checksum = "82b3477e195e070996649e455dc5ff8af7aae4032209f738958679f5bbd17409"
 dependencies = [
  "bindgen",
  "cc",
@@ -1680,14 +1687,14 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1813,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -1925,15 +1932,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1989,9 +1996,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1999,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2009,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2022,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
@@ -2197,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2359,16 +2366,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2407,7 +2414,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2439,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2679,9 +2686,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -2785,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -2862,10 +2869,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -2896,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2917,7 +2925,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2933,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2966,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3327,9 +3335,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3337,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -3352,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3364,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3374,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3387,15 +3395,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3437,6 +3445,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-admin-tool"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -22,10 +22,10 @@ pretty_env_logger = "0.4"
 nix = "0.26"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.7", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.8", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.8" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,6 +21,6 @@ libcryptsetup-rs = { version = "0.6.0", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.32"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -5,7 +5,7 @@
 %global forgeurl https://github.com/fedora-iot/fido-device-onboard-rs
 %global rpmdocsdir docs-rpms
 
-Version:        0.4.7
+Version:        0.4.8
 
 %forgemeta
 
@@ -231,6 +231,9 @@ Requires: fdo-owner-cli
 %systemd_postun_with_restart fdo-aio.service
 
 %changelog
+* Wed Feb 15 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.8-1
+- Update to 0.4.8
+
 * Wed Nov 30 2022 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.7-1
 - Update to 0.4.7
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10.45"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-store = { path = "../store", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-store = { path = "../store", version = "0.4.8" }
 aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -12,7 +12,7 @@
 
 #define FDO_DATA_MAJOR 0
 #define FDO_DATA_MINOR 4
-#define FDO_DATA_PATCH 7
+#define FDO_DATA_PATCH 8
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,6 +17,6 @@ passwd = "0.0.1"
 rand = "0.8.4"
 tss-esapi = "7.2"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ log = "0.4"
 hex = "0.4"
 serde_yaml = "0.9"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.7", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.8", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.7", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.8", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -16,9 +16,9 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 tss-esapi = "7.2"
 
-fdo-util = { path = "../util", version = "0.4.7" }
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.8" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["client"] }
 
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.7" }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.8" }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,7 +16,7 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server"] }
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-store = { path = "../store", version = "0.4.7", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.7" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-store = { path = "../store", version = "0.4.8", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.8" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fdo-store"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
 
 config = "0.13.3"
 futures = "0.3"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ glob = "0.3.1"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.7" }
-fdo-store = { path = "../store", version = "0.4.7" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.7", features = ["server", "client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.8" }
+fdo-store = { path = "../store", version = "0.4.8" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.8", features = ["server", "client"] }
 serde_yaml = "0.9"
 serde_cbor = "0.11"
 serde_json = "1"


### PR DESCRIPTION
Prepare for the 0.4.8 release.
Update Cargo.lock file.