### PR TITLE
fix: do not start two servers with the same unit

### DIFF
--- a/examples/systemd/fdo-owner-onboarding-server.service
+++ b/examples/systemd/fdo-owner-onboarding-server.service
@@ -5,7 +5,6 @@ After=network-online.target
 [Service]
 Environment=LOG_LEVEL=info
 ExecStart=/usr/libexec/fdo/fdo-owner-onboarding-server
-ExecStartPost=/usr/libexec/fdo/fdo-serviceinfo-api-server
 # restart and failure condition
 
 [Install]


### PR DESCRIPTION
We'll go back to the way we used to start `fdo-owner-onboarding-server` and `fdo-serviceinfo-api-server`, with two separate systemd unit files that started each server and that's it.

The .spec file already ships each unit on `fdo-owner-onboarding-server` so on that RPM the user has everything that they need to start each server.