### PR TITLE
chore: don't require an explicit minor release of reqwest

### DIFF
--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -29,7 +29,7 @@ warp-sessions = { version = "1.0", optional = true }
 time = "0.3"
 
 # Client-side
-reqwest = { version = "0.11.14", optional = true, features = ["native-tls", "json"] }
+reqwest = { version = "0.11", optional = true, features = ["native-tls", "json"] }
 url = { version = "2", optional = true }
 
 [features]


### PR DESCRIPTION
The reqwest crate is used in a number of places in FDO but it's only specified as minor releases in in the http-wrapper side of things. Let's align major versions as per the rest of the project.