### PR TITLE
fix(ci): missing dependencies due to the new Fedora release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Install deps
         run: |
-          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel swtpm swtpm-tools cargo rust git clevis clevis-luks cryptsetup cryptsetup-devel clang-devel
+          dnf install -y make gcc openssl openssl-devel findutils golang git tpm2-tss-devel swtpm swtpm-tools cargo rust git clevis clevis-luks cryptsetup cryptsetup-devel clang-devel cracklib-dicts
       - uses: actions/checkout@v3
         with:
           persist-credentials: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ There are a number of ways in which you can set up development environments for 
 In order to make a test build of this crate, when using Fedora, you can run:
 
 ``` bash
-sudo yum install -y cargo rust rust-src git-core openssl-devel clippy rustfmt golang tpm2-tss-devel clevis clevis-luks cryptsetup cryptsetup-devel clang-devel
+sudo yum install -y cargo rust rust-src git-core openssl-devel clippy rustfmt golang tpm2-tss-devel clevis clevis-luks cryptsetup cryptsetup-devel clang-devel cracklib-dicts
 git clone https://github.com/fedora-iot/fido-device-onboard-rs.git
 cd fido-device-onboard-rs
 cargo build --release


### PR DESCRIPTION
We use the latest Fedora version in a container to run our CI tests, due to the new release `/usr/share/cracklib/pw_dict.pwd.gz` is missing. This adds the `cracklib-dicts` package which provides the missing pieces.