### PR TITLE
chore(admin-tool): don't specify an explicit minor version for time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "serde",
  "time-core",

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 config = "0.13.3"
 openssl = "0.10.45"
 log = "0.4"
-time = "0.3.19"
+time = "0.3"
 clap = { version = "4.1", features = ["derive"] }
 futures = "0.3"
 reqwest = "0.11"


### PR DESCRIPTION
Other modules in the project (rendezvous-server, store, http-wrapper and owner-onboarding-server) that also require `time` do not set an explicit minor version, so standardise this practice.

We did the same thing with `reqwest` on #427 .
This would close the automatic PR #429 from the bot too.