### PR TITLE
fix(serviceinfo): no authentication is needed when omitting `service_info_auth_token`

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -469,8 +469,8 @@ service_info:
 
 Where:
 - `bind`: IP address and port that the Service Info API Server will take.
-- `service_info_auth_token`: Authorization token, `None` if no authentication
-  is needed.
+- `service_info_auth_token`: [OPTIONAL] Authorization token (default no authentication
+   is needed).
 - `admin_auth_token`: [OPTIONAL] Admin's authorization token.
 - `device_specific_store_driver`: path to a directory that will hold
   device-specific info.

--- a/admin-tool/src/aio/configure.rs
+++ b/admin-tool/src/aio/configure.rs
@@ -224,7 +224,7 @@ fn generate_configs(aio_dir: &Path, config_args: &Configuration) -> Result<(), E
 
             bind: get_bind(config_args.listen_port_serviceinfo_api_server)?,
 
-            service_info_auth_token: config_args.serviceinfo_api_auth_token.clone(),
+            service_info_auth_token: Some(config_args.serviceinfo_api_auth_token.clone()),
             admin_auth_token: Some(config_args.serviceinfo_api_admin_token.clone()),
 
             device_specific_store_driver: StoreConfig::Directory {

--- a/util/src/servers/configuration/serviceinfo_api_server.rs
+++ b/util/src/servers/configuration/serviceinfo_api_server.rs
@@ -11,7 +11,7 @@ pub struct ServiceInfoApiServerSettings {
     pub service_info: ServiceInfoSettings,
     pub bind: Bind,
 
-    pub service_info_auth_token: String,
+    pub service_info_auth_token: Option<String>,
     pub admin_auth_token: Option<String>,
 
     #[serde(with = "serde_yaml::with::singleton_map")]


### PR DESCRIPTION
This patch supports no authentication for service info by using `Option()`
for `service_info_auth_token`.

Current docs asks users to set `None` if no authentication is needed but
`serde_yaml` library does not handle the `None` as Rust's `None`. 
So this patch supports `service_info_auth_token` as `Option()` to allow
"no authentication is needed" when it is omitted.

Alternatively it is possible to support `"None"` or `""` (empty string)
as a special case to disable authorization. Any suggestion is welcome.

Fix https://github.com/fedora-iot/fido-device-onboard-rs/issues/403