### PR TITLE
chore: add 'marshalling' to spellcheck-ignore

### DIFF
--- a/.github/spellcheck-ignore
+++ b/.github/spellcheck-ignore
@@ -4,3 +4,4 @@ stdio
 ser
 childs
 ot
+marshalling


### PR DESCRIPTION
Both marshalling and marshaling are accepted words in Computer Science, see: https://en.wikipedia.org/wiki/Marshalling_(computer_science)

This unblocks #441 