### PR TITLE
feat(data-formats): Support encoding the large number by cborparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ name = "fdo-data-formats"
 version = "0.4.9"
 dependencies = [
  "aws-nitro-enclaves-cose",
+ "byteorder",
  "ciborium",
  "hex",
  "http",

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -24,6 +24,7 @@ num-derive = "0.3"
 paste = "1.0"
 pem = "1.1"
 tss-esapi = "7.2"
+byteorder = "1"
 
 http = "0.2"
 hyper = "0.14"


### PR DESCRIPTION
As per `TODO` comment, current code does not support the value larther than 23 even though `read_len()` function supports it.

This patch adds the support.

Fix https://github.com/fedora-iot/fido-device-onboard-rs/issues/463