### PR TITLE
chore: add serviceinfo API server to crates list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Untrusted Networks (DIUN) protocols.
 - `fdo-store`: Implementation of different backend datastores for services.
 - `fdo-util`: Utilities/helpers for server (and, in the future client) crates.
 - `fdo-iot-stream-message`: Implements the stream message creation/parsing of StreamMsg. Currently not implemented.
+- `fdo-serviceinfo-api-server`: Service Info API Server implementation. The specification is written in [serviceinfo_api.md](./docs/specs/serviceinfo_api.md).
 
 ## RPMs and containers
 

--- a/docs/specs/serviceinfo_api.md
+++ b/docs/specs/serviceinfo_api.md
@@ -24,7 +24,7 @@ Requests and responses for the Management API use JSON encoding, instead of the 
 
 #### Authentication
 
-For this protocol, the FDO Owner Onboarding Server will authenticate to the server of this API, via any of the authentication methods defined in the [OV Management API specification](https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/specs/ov_management_api.md#authentication).
+For this protocol, the FDO Owner Onboarding Server will authenticate to the server of this API, via any of the authentication methods defined in the [OV Management API specification](./ov_management_api.md#authentication).
 
 ### Endpoint
 


### PR DESCRIPTION
This patch adds missing [fdo-serviceinfo-api-server](https://github.com/fedora-iot/fido-device-onboard-rs/tree/main/serviceinfo-api-server) to the crates list in README.md.