### PR TITLE
chore: bump pem from 1.1.1 to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,11 +1979,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
+ "serde",
 ]
 
 [[package]]

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -22,7 +22,7 @@ uuid = "1.3"
 num-traits = "0.2"
 num-derive = "0.3"
 paste = "1.0"
-pem = "1.1"
+pem = "2.0"
 tss-esapi = "7.2"
 
 http = "0.2"

--- a/data-formats/src/ownershipvoucher.rs
+++ b/data-formats/src/ownershipvoucher.rs
@@ -176,20 +176,20 @@ impl OwnershipVoucher {
 
     pub fn from_pem(data: &[u8]) -> Result<Self> {
         let parsed = pem::parse(data)?;
-        if parsed.tag != VOUCHER_PEM_TAG {
-            return Err(Error::InvalidPemTag(parsed.tag));
+        if parsed.tag() != VOUCHER_PEM_TAG {
+            return Err(Error::InvalidPemTag(parsed.tag().to_string()));
         }
-        Self::deserialize_data(&parsed.contents)
+        Self::deserialize_data(parsed.contents())
     }
 
     pub fn many_from_pem(data: &[u8]) -> Result<Vec<Self>> {
         pem::parse_many(data)?
             .into_iter()
             .map(|parsed| {
-                if parsed.tag == VOUCHER_PEM_TAG {
-                    Self::deserialize_from_reader(&*parsed.contents)
+                if parsed.tag() == VOUCHER_PEM_TAG {
+                    Self::deserialize_from_reader(parsed.contents())
                 } else {
-                    Err(Error::InvalidPemTag(parsed.tag))
+                    Err(Error::InvalidPemTag(parsed.tag().to_string()))
                 }
             })
             .collect()
@@ -204,10 +204,7 @@ impl OwnershipVoucher {
     }
 
     pub fn to_pem(&self) -> Result<String> {
-        let block = pem::Pem {
-            tag: VOUCHER_PEM_TAG.to_string(),
-            contents: self.serialize_data()?,
-        };
+        let block = pem::Pem::new(VOUCHER_PEM_TAG.to_string(), self.serialize_data()?);
         Ok(pem::encode(&block))
     }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0"
 pretty_assertions = "1.0.0"
 paste = "1.0"
 passwd = "0.0.1"
-pem = "1.1"
+pem = "2.0"
 users = "0.11.0"
 
 fdo-data-formats = { path = "../data-formats" }

--- a/integration-tests/tests/voucher_tests.rs
+++ b/integration-tests/tests/voucher_tests.rs
@@ -66,7 +66,7 @@ fn test_multiple_vouchers_raw() -> Result<()> {
             count += 1;
 
             let pemblock = pem::parse(&voucher).context("Error parsing OV PEM")?;
-            buffer.extend_from_slice(&pemblock.contents);
+            buffer.extend_from_slice(pemblock.contents());
 
             Ok(buffer)
         })?;


### PR DESCRIPTION
This PR picks up https://github.com/fedora-iot/fido-device-onboard-rs/pull/469 and fixes the build error by:
* Using `contents()` and `tag()` to access them.
* Using `pem::Pem::new()` to create a new Pem struct.
