### PR TITLE
feat(serviceinfo_api_server): implement per device Serviceinfo initial user and sshkey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Run tests
         env:
           FDO_PRIVILEGED: true
+          PER_DEVICE_SERVICEINFO: false
         run: cargo test
       - name: Check aio
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.19"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
  "itoa",

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -22,6 +22,8 @@
 - How to run the clients:
   - Linuxapp client
   - Manufacturing client
+- How to use Features:
+  - How to use the `per-device serviceinfo` feature
 
 ## Pre-requisites
 
@@ -734,3 +736,26 @@ Options:
 
 Please note that in this mode there are some environment variables that are
 still required to be set by the user (`DI_SIGN_KEY_PATH`, `DI_HMAC_KEY_PATH`).
+
+## How to use Features
+
+### How to use the `per-device serviceinfo` feature
+
+  Using this feature the user can choose to apply different serviceinfo settings on different devices.
+  For that the user needs to provide a path to a `per-device serviceinfo` file under the `device_specific_store_driver` field
+  present in the `serviceinfo_api_server.yml` file.
+  If other devices do not have their `per-device serviceinfo` file under `device_specific_store_driver` they will get onboarded
+  with settings from the main file, which is `serviceinfo_api_server.yml`.
+  
+  1. Initialize the device as mentioned in [How to generate an Ownership Voucher and Credential for a Device](#how-to-generate-an-ownership-voucher-ov-and-credential-for-a-device-device-initialization).
+
+  2. Dump the `device-credentials`
+  ```bash
+  fdo-owner-tool dump-device-credential /path/to/device-credentials
+  ```
+
+  3. Note the GUID of the device and create a .yml file with same name as the `guid` under directory path `device_specific_store_driver`.
+
+  4. You can refer to [per_device_serviceinfo.yml](https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/config/device_specific_serviceinfo.yml) as an example.
+
+  5. Follow the onboarding procedure and this particular device will get the serviceinfo settings as mentioned in the above file.

--- a/examples/config/device_specific_serviceinfo.yml
+++ b/examples/config/device_specific_serviceinfo.yml
@@ -1,0 +1,9 @@
+initial_user:
+  username: username_per_device
+  sshkeys:
+  - "testkeyperdevice"
+files: null
+commands: null
+diskencryption_clevis: null
+additional_serviceinfo: null
+after_onboarding_reboot: false

--- a/integration-tests/templates/serviceinfo-api-server.yml.j2
+++ b/integration-tests/templates/serviceinfo-api-server.yml.j2
@@ -9,7 +9,7 @@ service_info:
   initial_user:
     username: {{ user }}
     sshkeys:
-    - "testkey"
+    - {{ sshkey }}
   files:
   - path: /etc/hosts
     permissions: 644

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -263,7 +263,7 @@ async fn test_to_impl(
             .context("Error reading authorized SSH keys")?,
         "
 # These keys are installed by FIDO Device Onboarding
-testkey
+sshkey_default
 # End of FIDO Device Onboarding keys
 "
     );

--- a/util/src/servers/configuration/serviceinfo_api_server.rs
+++ b/util/src/servers/configuration/serviceinfo_api_server.rs
@@ -19,6 +19,7 @@ pub struct ServiceInfoApiServerSettings {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ServiceInfoSettings {
     pub initial_user: Option<ServiceInfoInitialUser>,
 

--- a/util/src/servers/mod.rs
+++ b/util/src/servers/mod.rs
@@ -1,18 +1,19 @@
+use anyhow::{bail, Context, Result};
 use config::Config;
 use fdo_data_formats::constants::ServiceInfoModule;
+use fdo_store::StoreConfig;
 use glob::glob;
 use serde::{Deserialize, Serialize};
-use std::env;
-use std::path::Path;
-use fdo_store::{StoreConfig};
-use anyhow::{bail, Context, Result};
 use serde_cbor::Value as CborValue;
 use serde_yaml::Value;
+use std::env;
+use std::path::Path;
 use std::result::Result::Ok;
 
 pub mod configuration;
-use crate::servers::configuration::serviceinfo_api_server::{ServiceInfoApiServerSettings, ServiceInfoSettings};
-
+use crate::servers::configuration::serviceinfo_api_server::{
+    ServiceInfoApiServerSettings, ServiceInfoSettings,
+};
 
 // TODO(runcom): find a better home for this as it's shared between
 // owner-onboarding-server and manufacturing-server...
@@ -62,17 +63,14 @@ pub fn settings_for(component: &str) -> Result<config::Config> {
 pub fn settings_per_device(guid: &str) -> Result<ServiceInfoSettings> {
     // here we first check if the requested device has per-device file stored
     // in device_specific_store_driver, if not return error
-    
+
     let settings: ServiceInfoApiServerSettings = settings_for("serviceinfo-api-server")?
-    .try_deserialize()
-    .context("Error parsing configuration")?;
-   
+        .try_deserialize()
+        .context("Error parsing configuration")?;
+
     let path_per_device_store = match settings.device_specific_store_driver {
         StoreConfig::Directory { mut path } => {
-            let file_name = format!(
-                "{}.yml",
-                guid
-            );
+            let file_name = format!("{}.yml", guid);
             path.push(file_name);
             path.to_string_lossy().into_owned()
         }
@@ -97,7 +95,7 @@ pub fn settings_per_device(guid: &str) -> Result<ServiceInfoSettings> {
             .as_ref()
             .map(|user| &user.sshkeys)
     );
-    return Ok(per_device_settings);
+    Ok(per_device_settings)
 }
 
 pub fn format_conf_env(component: &str) -> String {


### PR DESCRIPTION
This PR 
- provides a way to user for adding different initial user and sshkey by using `device_specific_store_driver` feature.
- user has to provide a .yml file with the same name GUID of the device under `device_specific_store_driver` path.
- If no file is present for a device then base config is applied (from serviceinfo_api_server.yml).
- updated HOWTO.md
