### PR TITLE
feat(admin-tool): configure X509 certificate's expiration date 

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -48,28 +48,24 @@ Use `fdo-admin-tool generate-key-and-cert` to generate the required keys for
 `diun`, `manufacturer`, `device-ca` or `owner`. 
 
 ```bash
-USAGE:
-    fdo-admin-tool generate-key-and-cert [OPTIONS] <SUBJECT>
+Usage: fdo-admin-tool generate-key-and-cert [OPTIONS] <SUBJECT>
 
-ARGS:
-    <SUBJECT>    Subject of the key and certificate [possible values: diun, manufacturer,
-                 device-ca, owner]
+Arguments:
+  <SUBJECT>  Subject of the key and certificate [possible values: diun, manufacturer, device-ca, owner]
 
-OPTIONS:
-        --country <COUNTRY>
-            Country name for the certificate [default: US]
-
-        --destination-dir <DESTINATION_DIR>
-            Writes key and certificate to the given path [default: keys]
-
-    -h, --help
-            Print help information
-
-        --organization <ORGANIZATION>
-            Organization name for the certificate [default: Example]
-
-    -V, --version
-            Print version information
+Options:
+      --organization <ORGANIZATION>
+          Organization name for the certificate [default: Example]
+      --country <COUNTRY>
+          Country name for the certificate [default: US]
+      --validity-ends <VALIDITY_ENDS>
+          Number of days the certificate is going to be valid [default: 365]
+      --destination-dir <DESTINATION_DIR>
+          Writes key and certificate to the given path [default: keys]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 Note in the results that `.der` indicate private keys and `.pem` certificates.

--- a/admin-tool/src/aio/configure.rs
+++ b/admin-tool/src/aio/configure.rs
@@ -431,6 +431,7 @@ pub(super) fn generate_configs_and_keys(
             subject: key_subject,
             organization: config_args.cert_organization.clone(),
             country: config_args.cert_country.clone(),
+            validity_ends: 365,
             destination_dir: aio_dir.join("keys").to_string_lossy().to_string(),
         })
         .with_context(|| format!("Error creating {key_subject:?} key"))?;

--- a/admin-tool/src/main.rs
+++ b/admin-tool/src/main.rs
@@ -46,6 +46,7 @@ fn generate_key_and_cert(args: &GenerateKeyAndCertArguments) -> Result<(), Error
     let subject = args.subject;
     let organization_name = &args.organization;
     let country_name = &args.country;
+    let validity_ends = &args.validity_ends;
     let destination_dir = &args.destination_dir;
     let mut destination_dir_path = PathBuf::from(destination_dir);
     if !destination_dir_path.is_absolute() {
@@ -76,7 +77,7 @@ fn generate_key_and_cert(args: &GenerateKeyAndCertArguments) -> Result<(), Error
     builder.set_serial_number(&serial)?;
     builder.set_subject_name(&name)?;
     builder.set_issuer_name(&name)?;
-    builder.set_not_after(Asn1Time::days_from_now(365)?.as_ref())?;
+    builder.set_not_after(Asn1Time::days_from_now(validity_ends.to_owned())?.as_ref())?;
     builder.set_not_before(Asn1Time::days_from_now(0)?.as_ref())?;
     builder.set_pubkey(&pkey)?;
     builder.sign(&pkey, MessageDigest::sha256())?;
@@ -145,6 +146,9 @@ struct GenerateKeyAndCertArguments {
     /// Country name for the certificate
     #[clap(long, default_value_t = String::from("US"))]
     country: String,
+    /// Number of days the certificate is going to be valid
+    #[clap(long, default_value_t = 365)]
+    validity_ends: u32,
     /// Writes key and certificate to the given path
     #[clap(long, default_value_t = String::from("keys"))]
     destination_dir: String,


### PR DESCRIPTION
Currently with the `generate-key-and-cert` option of the
`fdo-admin-tool` cli we can configure the 'Country' and
'Organization' name of the generated X509 certificate, and we
set by default a 365-day validity period.

This allows to set an specific number of days for the certificate's
validity period with the new `--validity-ends` option.