### PR TITLE
chore: bump for 0.4.10 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-admin-tool"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-client-linuxapp"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "devicemapper",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "assert-str",
  "cbindgen",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data-formats"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "byteorder",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-http-wrapper"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-client"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "config",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-onboarding-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "config",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-tool"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-rendezvous-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "config",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "config",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-store"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "config",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-util"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "config",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "fdo-data-formats",

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-admin-tool"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -22,10 +22,10 @@ pretty_env_logger = "0.4"
 nix = "0.26"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.9", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.10" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,6 +21,6 @@ libcryptsetup-rs = { version = "0.7.0", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.33"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10.48"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-store = { path = "../store", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-store = { path = "../store", version = "0.4.10" }
 aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -12,7 +12,7 @@
 
 #define FDO_DATA_MAJOR 0
 #define FDO_DATA_MINOR 4
-#define FDO_DATA_PATCH 9
+#define FDO_DATA_PATCH 10
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -19,6 +19,6 @@ rand = "0.8.4"
 tss-esapi = "7.2"
 regex = "1.3.7"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ log = "0.4"
 hex = "0.4"
 serde_yaml = "0.9"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.9", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.9", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -16,9 +16,9 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 tss-esapi = "7.2"
 
-fdo-util = { path = "../util", version = "0.4.9" }
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
 
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.9" }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.10" }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,7 +16,7 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server"] }
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-store = { path = "../store", version = "0.4.9", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.9" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.10" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fdo-store"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
 
 config = "0.13.3"
 futures = "0.3"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ glob = "0.3.1"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.9" }
-fdo-store = { path = "../store", version = "0.4.9" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.9", features = ["server", "client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-store = { path = "../store", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
 serde_yaml = "0.9"
 serde_cbor = "0.11"
 serde_json = "1"


### PR DESCRIPTION
Prepare for the 0.4.10 release.
Update Cargo.lock file.