### PR TITLE
chore: update libcryptsetup to 0.8.0 and fix API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,9 +1570,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9bf2004df62b9820328e6a2ffa603b694ac2cb4d683057fb58938c38ba9abd"
+checksum = "54de25d80cf59c099a01fc9939251bbf8021c131adf97beb7d57c094b16ed474"
 dependencies = [
  "bitflags",
  "either",

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.8.4"
 nix = "0.26"
 uuid = "1.3"
 thiserror = "1"
-libcryptsetup-rs = { version = "0.7.0", features = ["mutex"] }
+libcryptsetup-rs = { version = "0.8.0", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.33"
 

--- a/client-linuxapp/src/reencrypt/mod.rs
+++ b/client-linuxapp/src/reencrypt/mod.rs
@@ -64,7 +64,7 @@ fn perform_reencrypt(dev_name: &str) -> Result<()> {
         .context("Error opening device")?;
 
     dev.context_handle()
-        .load::<libcryptsetup_rs::CryptParamsLuks2>(None, None)
+        .load::<()>(None, None)
         .context("Error loading device context")?;
 
     let status = dev

--- a/client-linuxapp/src/reencrypt/rebind.rs
+++ b/client-linuxapp/src/reencrypt/rebind.rs
@@ -154,7 +154,7 @@ fn clevis_bind(
     log::trace!("Clevis bind successful");
 
     dev.context_handle()
-        .load::<libcryptsetup_rs::CryptParamsLuks2>(None, None)
+        .load::<()>(None, None)
         .context("Error re-loading device context")?;
 
     log::trace!("Reloaded device context");

--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -253,7 +253,7 @@ impl DiskEncryptionInProgress {
         log::debug!("Device initiated");
 
         dev.context_handle()
-            .load::<libcryptsetup_rs::CryptParamsLuks2>(None, None)
+            .load::<()>(None, None)
             .context("Error loading device context")?;
 
         log::debug!("Device information loaded");


### PR DESCRIPTION
This potentially allows us to bump `libcryptsetup` to 0.8.0.

Closes #508 

