### PR TITLE
fix: explicitly mark LUKS2 for context load

### DIFF
--- a/client-linuxapp/src/reencrypt/mod.rs
+++ b/client-linuxapp/src/reencrypt/mod.rs
@@ -64,7 +64,7 @@ fn perform_reencrypt(dev_name: &str) -> Result<()> {
         .context("Error opening device")?;
 
     dev.context_handle()
-        .load::<()>(None, None)
+        .load::<libcryptsetup_rs::CryptParamsLuks2Ref>(None, None)
         .context("Error loading device context")?;
 
     let status = dev

--- a/client-linuxapp/src/reencrypt/rebind.rs
+++ b/client-linuxapp/src/reencrypt/rebind.rs
@@ -154,7 +154,7 @@ fn clevis_bind(
     log::trace!("Clevis bind successful");
 
     dev.context_handle()
-        .load::<()>(None, None)
+        .load::<libcryptsetup_rs::CryptParamsLuks2Ref>(None, None)
         .context("Error re-loading device context")?;
 
     log::trace!("Reloaded device context");

--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -320,7 +320,7 @@ impl DiskEncryptionInProgress {
         log::debug!("Device initiated");
 
         dev.context_handle()
-            .load::<()>(None, None)
+            .load::<libcryptsetup_rs::CryptParamsLuks2Ref>(None, None)
             .context("Error loading device context")?;
 
         log::debug!("Device information loaded");


### PR DESCRIPTION
This explicitly marks LUKS2 as the load context to avoid getting `Operation incompatible with device marked for LUKS2 reencryption` errors.

Fixes rhbz#2216111