### PR TITLE
chore: update ssh-key format in tests to match real-world usage

### DIFF
--- a/client-linuxapp/src/serviceinfo.rs
+++ b/client-linuxapp/src/serviceinfo.rs
@@ -718,7 +718,7 @@ async fn process_serviceinfo_in(si_in: &ServiceInfo, si_out: &mut ServiceInfo) -
             ))?;
             let sshkey_keys_v: Vec<String> = sshkey_keys
                 .unwrap()
-                .split(' ')
+                .split(';')
                 .map(|s| s.to_string())
                 .collect();
             for key in sshkey_keys_v {

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -807,7 +807,7 @@ impl<'a> TestServerConfigurator<'a> {
                         "user",
                         users::get_current_username().unwrap().to_str().unwrap(),
                     );
-                    cfg.insert("sshkey", "sshkey_default");
+                    cfg.insert("sshkey", "ssh-ed25519 sshkey_default user@example.com");
                     cfg.insert("password", "testpassword");
                 } else {
                     L.l("per_device_serviceinfo is set, using device specific values");
@@ -815,7 +815,7 @@ impl<'a> TestServerConfigurator<'a> {
                         "user",
                         users::get_current_username().unwrap().to_str().unwrap(),
                     );
-                    cfg.insert("sshkey", "sshkey_per_device");
+                    cfg.insert("sshkey", "ssh-ed25519 sshkey_per_device user@example.com");
                     cfg.insert("password", "testpassword");
                 }
 

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -394,7 +394,7 @@ where
             .context("Error reading authorized SSH keys")?,
         "
 # These keys are installed by FIDO Device Onboarding
-sshkey_default
+ssh-ed25519 sshkey_default user@example.com
 # End of FIDO Device Onboarding keys
 "
     );
@@ -650,7 +650,7 @@ where
             .context("Error reading authorized per device SSH keys")?,
         "
 # These keys are installed by FIDO Device Onboarding
-sshkey_per_device
+ssh-ed25519 sshkey_per_device user@example.com
 # End of FIDO Device Onboarding keys
 "
     );

--- a/integration-tests/tests/service_info.rs
+++ b/integration-tests/tests/service_info.rs
@@ -271,7 +271,7 @@ where
             .context("Error reading authorized SSH keys")?,
         "
 # These keys are installed by FIDO Device Onboarding
-sshkey_default
+ssh-ed25519 sshkey_default user@example.com
 # End of FIDO Device Onboarding keys
 "
     );

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -263,7 +263,7 @@ async fn test_to_impl(
             .context("Error reading authorized SSH keys")?,
         "
 # These keys are installed by FIDO Device Onboarding
-sshkey_default
+ssh-ed25519 sshkey_default user@example.com
 # End of FIDO Device Onboarding keys
 "
     );

--- a/owner-onboarding-server/src/handlers.rs
+++ b/owner-onboarding-server/src/handlers.rs
@@ -549,7 +549,7 @@ async fn perform_service_info(
             out_si.add(
                 FedoraIotServiceInfoModule::SSHKey,
                 "sshkeys",
-                &(initial_user.ssh_keys.unwrap().join(" ")),
+                &(initial_user.ssh_keys.unwrap().join(";")),
             )?;
         }
     }


### PR DESCRIPTION
This change allows us to reproduce [RHBZ#2218231](https://bugzilla.redhat.com/show_bug.cgi?id=2218231) (and to catch more related bugs in the future)

and it also fixes that same BZ.

Our FSIM for creating users with an associated ssh key did
not take into account that ssh keys are strings that may
have spaces, e.g. 'ssh-ed25519 long-string user@example.com',
and used ' ' as the split character.

This sets ';' as the split character in the FSIM avoiding
installing unusable ssh keys.
