### PR TITLE
Update rpm spec file and prepare for 0.4.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
@@ -236,6 +237,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 1.0.109",
+ "which",
 ]
 
 [[package]]
@@ -769,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-admin-tool"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -794,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-client-linuxapp"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "devicemapper",
@@ -819,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "assert-str",
  "cbindgen",
@@ -831,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data-formats"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "byteorder",
@@ -859,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-http-wrapper"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",
@@ -882,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-client"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -902,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "config",
@@ -922,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-onboarding-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "config",
@@ -945,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-tool"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -963,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-rendezvous-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "config",
@@ -982,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "config",
@@ -1001,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-store"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-trait",
  "config",
@@ -1018,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-util"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "config",
@@ -1480,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "fdo-data-formats",
@@ -3047,6 +3049,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b8be553262e0924410fe96404830252477f175f228081f21cb0bd87f2ccebe"
 dependencies = [
+ "bindgen",
  "pkg-config",
  "target-lexicon",
 ]
@@ -3382,6 +3385,17 @@ checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-admin-tool"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -22,10 +22,10 @@ pretty_env_logger = "0.4"
 nix = "0.26"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.11", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.11" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -24,6 +24,6 @@ openssl = "0.10.55"
 sha-crypt = "0.5.0"
 logtest = "2.0.0"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 paste = "1.0"
 pem = "2.0"
-tss-esapi = "7.2"
+tss-esapi = { version = "7.2", features = ["generate-bindings"] }
 byteorder = "1"
 
 http = "0.2"

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -1,472 +1,56 @@
-%define dracutlibdir %{_prefix}/lib/dracut
+%global dracutlibdir %{_prefix}/lib/dracut
 %bcond_without check
-%global __cargo_skip_build 0
-%global __cargo_is_lib() false
-%global with_bundled 1
-%global with_packit 0
-%global forgeurl https://github.com/fedora-iot/fido-device-onboard-rs
-%global rpmdocsdir docs-rpms
-
-Version:        0.4.9
-
-%forgemeta
+%global combined_license Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache 2.0) AND ISC AND MIT AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (Apache-2.0 OR MIT OR Zlib) AND MPL-2.0 AND (Unlicense OR MIT)
 
 Name:           fido-device-onboard
+Version:        0.4.10
 Release:        1%{?dist}
-Summary:        An implementation of the FIDO Device Onboard Specification written in rust
+Summary:        A rust implementation of the FIDO Device Onboard Specification
+License:        BSD-3-Clause
 
-# Apache-2.0
-# Apache-2.0 OR BSL-1.0
-# Apache-2.0 OR ISC OR MIT
-# Apache-2.0 OR MIT
-# (Apache-2.0 OR MIT) AND BSD-3-Clause
-# Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
-# BSD-2-Clause
-# BSD-3-Clause
-# CC0-1.0
-# CC0-1.0 OR Apache-2.0
-# ISC
-# MIT
-# MIT OR Apache-2.0
-# MIT OR Apache-2.0 OR Zlib
-# MPL-2.0
-# Unlicense OR MIT
-# Zlib OR Apache-2.0 OR MIT
+URL:            https://github.com/fedora-iot/fido-device-onboard-rs
+Source0:        %{url}/archive/v%{version}/%{name}-rs-%{version}.tar.gz
+# See make-vendored-tarfile.sh in upstream repo
+Source1:        %{name}-rs-%{version}-vendor-patched.tar.xz
+# From upstream
+Patch0:         0001-chore-update-libcryptsetup-rs-to-0.8.patch
 
-License:        Apache-2.0 and BSD and MIT
-URL:            %{forgeurl}
-Source:         %{forgesource}
-# this is a basic script to generate the vendor tarfile from the source git.
-Source1:        make-vendored-tarfile.sh
-%if ! 0%{?with_packit}
-%if "%{?commit}" != ""
-Source2:        %{name}-rs-%{commit}-vendor.tar.gz
-%else
-Source2:        %{name}-rs-%{version}-vendor.tar.gz
-%endif
-%endif
+# Because nobody cares
+ExcludeArch: %{ix86}
 
-ExclusiveArch:  %{rust_arches}
-# RHBZ 1869980
-ExcludeArch:    s390x i686 %{power64}
-
-%if 0%{?rhel} && !0%{?eln}
+%if 0%{?rhel}
 BuildRequires:  rust-toolset
 %else
 BuildRequires:  rust-packaging
 %endif
-BuildRequires: systemd-rpm-macros
-BuildRequires: openssl-devel >= 3.0.1-12
-BuildRequires: golang
-BuildRequires: tpm2-tss-devel
-BuildRequires: cryptsetup-devel
-BuildRequires: clang-devel
-BuildRequires: make
-BuildRequires: python3-docutils
-# List of bundled crate in vendor tarball, generated with:
-# cargo metadata --locked --format-version 1 | CRATE_NAME="fido-device-onboard-rs" ./bundled-provides.jq
-# TODO: fido is multi crate, let's investigate how to do this properly...
-Provides: bundled(crate(ahash)) = 0.7.6
-Provides: bundled(crate(aho-corasick)) = 0.7.20
-Provides: bundled(crate(android_system_properties)) = 0.1.5
-Provides: bundled(crate(anyhow)) = 1.0.70
-Provides: bundled(crate(arrayref)) = 0.3.7
-Provides: bundled(crate(arrayvec)) = 0.5.2
-Provides: bundled(crate(assert-str)) = 0.1.0
-Provides: bundled(crate(async-lock)) = 2.7.0
-Provides: bundled(crate(async-session)) = 3.0.0
-Provides: bundled(crate(async-trait)) = 0.1.68
-Provides: bundled(crate(atty)) = 0.2.14
-Provides: bundled(crate(autocfg)) = 1.1.0
-Provides: bundled(crate(aws-nitro-enclaves-cose)) = 0.4.0
-Provides: bundled(crate(base64)) = 0.13.1
-Provides: bundled(crate(base64)) = 0.21.0
-Provides: bundled(crate(bincode)) = 1.3.3
-Provides: bundled(crate(bindgen)) = 0.63.0
-Provides: bundled(crate(bitfield)) = 0.13.2
-Provides: bundled(crate(bitflags)) = 1.3.2
-Provides: bundled(crate(blake3)) = 0.3.8
-Provides: bundled(crate(block-buffer)) = 0.9.0
-Provides: bundled(crate(block-buffer)) = 0.10.4
-Provides: bundled(crate(bstr)) = 1.4.0
-Provides: bundled(crate(buf_redux)) = 0.8.4
-Provides: bundled(crate(bumpalo)) = 3.12.0
-Provides: bundled(crate(byteorder)) = 1.4.3
-Provides: bundled(crate(bytes)) = 1.4.0
-Provides: bundled(crate(cbindgen)) = 0.24.3
-Provides: bundled(crate(cc)) = 1.0.79
-Provides: bundled(crate(cexpr)) = 0.6.0
-Provides: bundled(crate(cfg-if)) = 0.1.10
-Provides: bundled(crate(cfg-if)) = 1.0.0
-Provides: bundled(crate(chrono)) = 0.4.24
-Provides: bundled(crate(chrono-tz)) = 0.6.1
-Provides: bundled(crate(chrono-tz-build)) = 0.0.2
-Provides: bundled(crate(ciborium)) = 0.2.0
-Provides: bundled(crate(ciborium-io)) = 0.2.0
-Provides: bundled(crate(ciborium-ll)) = 0.2.0
-Provides: bundled(crate(clang-sys)) = 1.6.0
-Provides: bundled(crate(clap)) = 3.2.23
-Provides: bundled(crate(clap)) = 4.1.14
-Provides: bundled(crate(clap_builder)) = 4.1.14
-Provides: bundled(crate(clap_derive)) = 4.1.14
-Provides: bundled(crate(clap_lex)) = 0.2.4
-Provides: bundled(crate(clap_lex)) = 0.4.0
-Provides: bundled(crate(codespan-reporting)) = 0.11.1
-Provides: bundled(crate(config)) = 0.13.3
-Provides: bundled(crate(constant_time_eq)) = 0.1.5
-Provides: bundled(crate(core-foundation)) = 0.9.3
-Provides: bundled(crate(core-foundation-sys)) = 0.8.3
-Provides: bundled(crate(cpufeatures)) = 0.2.6
-Provides: bundled(crate(crypto-common)) = 0.1.6
-Provides: bundled(crate(crypto-mac)) = 0.8.0
-Provides: bundled(crate(crypto-mac)) = 0.11.1
-Provides: bundled(crate(ctor)) = 0.1.26
-Provides: bundled(crate(cxx)) = 1.0.94
-Provides: bundled(crate(cxx-build)) = 1.0.94
-Provides: bundled(crate(cxxbridge-flags)) = 1.0.94
-Provides: bundled(crate(cxxbridge-macro)) = 1.0.94
-Provides: bundled(crate(dashmap)) = 5.4.0
-Provides: bundled(crate(deunicode)) = 0.4.3
-Provides: bundled(crate(devicemapper)) = 0.33.2
-Provides: bundled(crate(devicemapper-sys)) = 0.1.5
-Provides: bundled(crate(diff)) = 0.1.13
-Provides: bundled(crate(digest)) = 0.9.0
-Provides: bundled(crate(digest)) = 0.10.6
-Provides: bundled(crate(dlv-list)) = 0.3.0
-Provides: bundled(crate(either)) = 1.8.1
-Provides: bundled(crate(encoding_rs)) = 0.8.32
-Provides: bundled(crate(enumflags2)) = 0.7.5
-Provides: bundled(crate(enumflags2_derive)) = 0.7.4
-Provides: bundled(crate(env_logger)) = 0.7.1
-Provides: bundled(crate(env_logger)) = 0.9.3
-Provides: bundled(crate(errno)) = 0.2.8
-Provides: bundled(crate(errno-dragonfly)) = 0.1.2
-Provides: bundled(crate(event-listener)) = 2.5.3
-Provides: bundled(crate(fastrand)) = 1.9.0
-Provides: bundled(crate(fdo-admin-tool)) = 0.4.9
-Provides: bundled(crate(fdo-client-linuxapp)) = 0.4.9
-Provides: bundled(crate(fdo-data)) = 0.4.9
-Provides: bundled(crate(fdo-data-formats)) = 0.4.9
-Provides: bundled(crate(fdo-http-wrapper)) = 0.4.9
-Provides: bundled(crate(fdo-manufacturing-client)) = 0.4.9
-Provides: bundled(crate(fdo-manufacturing-server)) = 0.4.9
-Provides: bundled(crate(fdo-owner-onboarding-server)) = 0.4.9
-Provides: bundled(crate(fdo-owner-tool)) = 0.4.9
-Provides: bundled(crate(fdo-rendezvous-server)) = 0.4.9
-Provides: bundled(crate(fdo-serviceinfo-api-server)) = 0.4.9
-Provides: bundled(crate(fdo-store)) = 0.4.9
-Provides: bundled(crate(fdo-util)) = 0.4.9
-Provides: bundled(crate(fnv)) = 1.0.7
-Provides: bundled(crate(foreign-types)) = 0.3.2
-Provides: bundled(crate(foreign-types-shared)) = 0.1.1
-Provides: bundled(crate(form_urlencoded)) = 1.1.0
-Provides: bundled(crate(futures)) = 0.3.27
-Provides: bundled(crate(futures-channel)) = 0.3.27
-Provides: bundled(crate(futures-core)) = 0.3.27
-Provides: bundled(crate(futures-executor)) = 0.3.27
-Provides: bundled(crate(futures-io)) = 0.3.27
-Provides: bundled(crate(futures-macro)) = 0.3.27
-Provides: bundled(crate(futures-sink)) = 0.3.27
-Provides: bundled(crate(futures-task)) = 0.3.27
-Provides: bundled(crate(futures-util)) = 0.3.27
-Provides: bundled(crate(generic-array)) = 0.14.7
-Provides: bundled(crate(getrandom)) = 0.2.8
-Provides: bundled(crate(glob)) = 0.3.1
-Provides: bundled(crate(globset)) = 0.4.10
-Provides: bundled(crate(globwalk)) = 0.8.1
-Provides: bundled(crate(h2)) = 0.3.16
-Provides: bundled(crate(half)) = 1.8.2
-Provides: bundled(crate(hashbrown)) = 0.12.3
-Provides: bundled(crate(headers)) = 0.3.8
-Provides: bundled(crate(headers-core)) = 0.2.0
-Provides: bundled(crate(heck)) = 0.4.1
-Provides: bundled(crate(hermit-abi)) = 0.1.19
-Provides: bundled(crate(hermit-abi)) = 0.2.6
-Provides: bundled(crate(hermit-abi)) = 0.3.1
-Provides: bundled(crate(hex)) = 0.4.3
-Provides: bundled(crate(hmac)) = 0.11.0
-Provides: bundled(crate(hostname-validator)) = 1.1.1
-Provides: bundled(crate(http)) = 0.2.9
-Provides: bundled(crate(http-body)) = 0.4.5
-Provides: bundled(crate(httparse)) = 1.8.0
-Provides: bundled(crate(httpdate)) = 1.0.2
-Provides: bundled(crate(humansize)) = 2.1.3
-Provides: bundled(crate(humantime)) = 1.3.0
-Provides: bundled(crate(humantime)) = 2.1.0
-Provides: bundled(crate(hyper)) = 0.14.25
-Provides: bundled(crate(hyper-tls)) = 0.5.0
-Provides: bundled(crate(iana-time-zone)) = 0.1.54
-Provides: bundled(crate(iana-time-zone-haiku)) = 0.1.1
-Provides: bundled(crate(idna)) = 0.3.0
-Provides: bundled(crate(ignore)) = 0.4.20
-Provides: bundled(crate(indexmap)) = 1.9.3
-Provides: bundled(crate(instant)) = 0.1.12
-Provides: bundled(crate(integration-tests)) = 0.4.9
-Provides: bundled(crate(io-lifetimes)) = 1.0.9
-Provides: bundled(crate(ipnet)) = 2.7.2
-Provides: bundled(crate(is-terminal)) = 0.4.5
-Provides: bundled(crate(itoa)) = 1.0.6
-Provides: bundled(crate(js-sys)) = 0.3.61
-Provides: bundled(crate(json5)) = 0.4.1
-Provides: bundled(crate(lazy_static)) = 1.4.0
-Provides: bundled(crate(lazycell)) = 1.3.0
-Provides: bundled(crate(libc)) = 0.2.140
-Provides: bundled(crate(libcryptsetup-rs)) = 0.6.1
-Provides: bundled(crate(libcryptsetup-rs-sys)) = 0.2.3
-Provides: bundled(crate(libloading)) = 0.7.4
-Provides: bundled(crate(libm)) = 0.2.6
-Provides: bundled(crate(link-cplusplus)) = 1.0.8
-Provides: bundled(crate(linked-hash-map)) = 0.5.6
-Provides: bundled(crate(linux-raw-sys)) = 0.1.4
-Provides: bundled(crate(lock_api)) = 0.4.9
-Provides: bundled(crate(log)) = 0.4.17
-Provides: bundled(crate(maplit)) = 1.0.2
-Provides: bundled(crate(mbox)) = 0.6.0
-Provides: bundled(crate(memchr)) = 2.5.0
-Provides: bundled(crate(memoffset)) = 0.7.1
-Provides: bundled(crate(mime)) = 0.3.17
-Provides: bundled(crate(mime_guess)) = 2.0.4
-Provides: bundled(crate(minimal-lexical)) = 0.2.1
-Provides: bundled(crate(mio)) = 0.8.6
-Provides: bundled(crate(multipart)) = 0.18.0
-Provides: bundled(crate(native-tls)) = 0.2.11
-Provides: bundled(crate(nix)) = 0.26.2
-Provides: bundled(crate(nom)) = 7.1.3
-Provides: bundled(crate(num-derive)) = 0.3.3
-Provides: bundled(crate(num-integer)) = 0.1.45
-Provides: bundled(crate(num-traits)) = 0.2.15
-Provides: bundled(crate(num_cpus)) = 1.15.0
-Provides: bundled(crate(oid)) = 0.2.1
-Provides: bundled(crate(once_cell)) = 1.17.1
-Provides: bundled(crate(opaque-debug)) = 0.3.0
-Provides: bundled(crate(openssl)) = 0.10.48
-Provides: bundled(crate(openssl-kdf)) = 0.4.1
-Provides: bundled(crate(openssl-macros)) = 0.1.0
-Provides: bundled(crate(openssl-probe)) = 0.1.5
-Provides: bundled(crate(openssl-sys)) = 0.9.83
-Provides: bundled(crate(ordered-multimap)) = 0.4.3
-Provides: bundled(crate(os_str_bytes)) = 6.5.0
-Provides: bundled(crate(output_vt100)) = 0.1.3
-Provides: bundled(crate(parking_lot)) = 0.12.1
-Provides: bundled(crate(parking_lot_core)) = 0.9.7
-Provides: bundled(crate(parse-zoneinfo)) = 0.3.0
-Provides: bundled(crate(passwd)) = 0.0.1
-Provides: bundled(crate(paste)) = 1.0.12
-Provides: bundled(crate(pathdiff)) = 0.2.1
-Provides: bundled(crate(peeking_take_while)) = 0.1.2
-Provides: bundled(crate(pem)) = 1.1.1
-Provides: bundled(crate(percent-encoding)) = 2.2.0
-Provides: bundled(crate(pest)) = 2.5.6
-Provides: bundled(crate(pest_derive)) = 2.5.6
-Provides: bundled(crate(pest_generator)) = 2.5.6
-Provides: bundled(crate(pest_meta)) = 2.5.6
-Provides: bundled(crate(phf)) = 0.10.1
-Provides: bundled(crate(phf_codegen)) = 0.10.0
-Provides: bundled(crate(phf_generator)) = 0.10.0
-Provides: bundled(crate(phf_shared)) = 0.10.0
-Provides: bundled(crate(picky-asn1)) = 0.3.3
-Provides: bundled(crate(picky-asn1-der)) = 0.2.5
-Provides: bundled(crate(picky-asn1-x509)) = 0.6.1
-Provides: bundled(crate(pin-project)) = 1.0.12
-Provides: bundled(crate(pin-project-internal)) = 1.0.12
-Provides: bundled(crate(pin-project-lite)) = 0.2.9
-Provides: bundled(crate(pin-utils)) = 0.1.0
-Provides: bundled(crate(pkg-config)) = 0.3.26
-Provides: bundled(crate(ppv-lite86)) = 0.2.17
-Provides: bundled(crate(pretty_assertions)) = 1.3.0
-Provides: bundled(crate(pretty_env_logger)) = 0.4.0
-Provides: bundled(crate(proc-macro2)) = 1.0.54
-Provides: bundled(crate(quick-error)) = 1.2.3
-Provides: bundled(crate(quote)) = 1.0.26
-Provides: bundled(crate(rand)) = 0.8.5
-Provides: bundled(crate(rand_chacha)) = 0.3.1
-Provides: bundled(crate(rand_core)) = 0.6.4
-Provides: bundled(crate(redox_syscall)) = 0.2.16
-Provides: bundled(crate(regex)) = 1.7.3
-Provides: bundled(crate(regex-syntax)) = 0.6.29
-Provides: bundled(crate(reqwest)) = 0.11.16
-Provides: bundled(crate(retry)) = 1.3.1
-Provides: bundled(crate(ron)) = 0.7.1
-Provides: bundled(crate(rust-ini)) = 0.18.0
-Provides: bundled(crate(rustc-hash)) = 1.1.0
-Provides: bundled(crate(rustc_version)) = 0.3.3
-Provides: bundled(crate(rustix)) = 0.36.11
-Provides: bundled(crate(rustls-pemfile)) = 0.2.1
-Provides: bundled(crate(ryu)) = 1.0.13
-Provides: bundled(crate(safemem)) = 0.3.3
-Provides: bundled(crate(same-file)) = 1.0.6
-Provides: bundled(crate(schannel)) = 0.1.21
-Provides: bundled(crate(scoped-tls)) = 1.0.1
-Provides: bundled(crate(scopeguard)) = 1.1.0
-Provides: bundled(crate(scratch)) = 1.0.5
-Provides: bundled(crate(secrecy)) = 0.8.0
-Provides: bundled(crate(security-framework)) = 2.8.2
-Provides: bundled(crate(security-framework-sys)) = 2.8.0
-Provides: bundled(crate(semver)) = 0.11.0
-Provides: bundled(crate(semver)) = 1.0.17
-Provides: bundled(crate(semver-parser)) = 0.10.2
-Provides: bundled(crate(serde)) = 1.0.159
-Provides: bundled(crate(serde_bytes)) = 0.11.9
-Provides: bundled(crate(serde_cbor)) = 0.11.2
-Provides: bundled(crate(serde_derive)) = 1.0.159
-Provides: bundled(crate(serde_json)) = 1.0.95
-Provides: bundled(crate(serde_repr)) = 0.1.12
-Provides: bundled(crate(serde_tuple)) = 0.5.0
-Provides: bundled(crate(serde_tuple_macros)) = 0.5.0
-Provides: bundled(crate(serde_urlencoded)) = 0.7.1
-Provides: bundled(crate(serde_with)) = 1.14.0
-Provides: bundled(crate(serde_yaml)) = 0.9.19
-Provides: bundled(crate(serial_test)) = 1.0.0
-Provides: bundled(crate(serial_test_derive)) = 1.0.0
-Provides: bundled(crate(sha-1)) = 0.10.1
-Provides: bundled(crate(sha1)) = 0.10.5
-Provides: bundled(crate(sha2)) = 0.9.9
-Provides: bundled(crate(sha2)) = 0.10.6
-Provides: bundled(crate(shlex)) = 1.1.0
-Provides: bundled(crate(signal-hook-registry)) = 1.4.1
-Provides: bundled(crate(siphasher)) = 0.3.10
-Provides: bundled(crate(slab)) = 0.4.8
-Provides: bundled(crate(slug)) = 0.1.4
-Provides: bundled(crate(smallvec)) = 1.10.0
-Provides: bundled(crate(socket2)) = 0.4.9
-Provides: bundled(crate(stable_deref_trait)) = 1.2.0
-Provides: bundled(crate(static_assertions)) = 1.1.0
-Provides: bundled(crate(strsim)) = 0.10.0
-Provides: bundled(crate(subtle)) = 2.4.1
-Provides: bundled(crate(syn)) = 1.0.109
-Provides: bundled(crate(syn)) = 2.0.11
-Provides: bundled(crate(sys-info)) = 0.9.1
-Provides: bundled(crate(target-lexicon)) = 0.12.6
-Provides: bundled(crate(tempfile)) = 3.4.0
-Provides: bundled(crate(tera)) = 1.18.1
-Provides: bundled(crate(termcolor)) = 1.2.0
-Provides: bundled(crate(textwrap)) = 0.16.0
-Provides: bundled(crate(thiserror)) = 1.0.40
-Provides: bundled(crate(thiserror-impl)) = 1.0.40
-Provides: bundled(crate(thread_local)) = 1.1.4
-Provides: bundled(crate(time)) = 0.3.20
-Provides: bundled(crate(time-core)) = 0.1.0
-Provides: bundled(crate(tinyvec)) = 1.6.0
-Provides: bundled(crate(tinyvec_macros)) = 0.1.1
-Provides: bundled(crate(tokio)) = 1.27.0
-Provides: bundled(crate(tokio-macros)) = 2.0.0
-Provides: bundled(crate(tokio-native-tls)) = 0.3.1
-Provides: bundled(crate(tokio-stream)) = 0.1.12
-Provides: bundled(crate(tokio-tungstenite)) = 0.17.2
-Provides: bundled(crate(tokio-util)) = 0.7.7
-Provides: bundled(crate(toml)) = 0.5.11
-Provides: bundled(crate(tower-service)) = 0.3.2
-Provides: bundled(crate(tracing)) = 0.1.37
-Provides: bundled(crate(tracing-core)) = 0.1.30
-Provides: bundled(crate(try-lock)) = 0.2.4
-Provides: bundled(crate(tss-esapi)) = 7.2.0
-Provides: bundled(crate(tss-esapi-sys)) = 0.4.0
-Provides: bundled(crate(tungstenite)) = 0.17.3
-Provides: bundled(crate(twoway)) = 0.1.8
-Provides: bundled(crate(typenum)) = 1.16.0
-Provides: bundled(crate(ucd-trie)) = 0.1.5
-Provides: bundled(crate(uncased)) = 0.9.7
-Provides: bundled(crate(unic-char-property)) = 0.9.0
-Provides: bundled(crate(unic-char-range)) = 0.9.0
-Provides: bundled(crate(unic-common)) = 0.9.0
-Provides: bundled(crate(unic-segment)) = 0.9.0
-Provides: bundled(crate(unic-ucd-segment)) = 0.9.0
-Provides: bundled(crate(unic-ucd-version)) = 0.9.0
-Provides: bundled(crate(unicase)) = 2.6.0
-Provides: bundled(crate(unicode-bidi)) = 0.3.13
-Provides: bundled(crate(unicode-ident)) = 1.0.8
-Provides: bundled(crate(unicode-normalization)) = 0.1.22
-Provides: bundled(crate(unicode-width)) = 0.1.10
-Provides: bundled(crate(unsafe-libyaml)) = 0.2.7
-Provides: bundled(crate(url)) = 2.3.1
-Provides: bundled(crate(users)) = 0.11.0
-Provides: bundled(crate(utf-8)) = 0.7.6
-Provides: bundled(crate(uuid)) = 1.3.0
-Provides: bundled(crate(vcpkg)) = 0.2.15
-Provides: bundled(crate(version_check)) = 0.9.4
-Provides: bundled(crate(walkdir)) = 2.3.3
-Provides: bundled(crate(want)) = 0.3.0
-Provides: bundled(crate(warp)) = 0.3.3
-Provides: bundled(crate(warp-sessions)) = 1.0.18
-Provides: bundled(crate(wasi)) = 0.11.0+wasi_snapshot_preview1
-Provides: bundled(crate(wasm-bindgen)) = 0.2.84
-Provides: bundled(crate(wasm-bindgen-backend)) = 0.2.84
-Provides: bundled(crate(wasm-bindgen-futures)) = 0.4.34
-Provides: bundled(crate(wasm-bindgen-macro)) = 0.2.84
-Provides: bundled(crate(wasm-bindgen-macro-support)) = 0.2.84
-Provides: bundled(crate(wasm-bindgen-shared)) = 0.2.84
-Provides: bundled(crate(web-sys)) = 0.3.61
-Provides: bundled(crate(winapi)) = 0.3.9
-Provides: bundled(crate(winapi-i686-pc-windows-gnu)) = 0.4.0
-Provides: bundled(crate(winapi-util)) = 0.1.5
-Provides: bundled(crate(winapi-x86_64-pc-windows-gnu)) = 0.4.0
-Provides: bundled(crate(windows)) = 0.46.0
-Provides: bundled(crate(windows-sys)) = 0.42.0
-Provides: bundled(crate(windows-sys)) = 0.45.0
-Provides: bundled(crate(windows-targets)) = 0.42.2
-Provides: bundled(crate(windows_aarch64_gnullvm)) = 0.42.2
-Provides: bundled(crate(windows_aarch64_msvc)) = 0.42.2
-Provides: bundled(crate(windows_i686_gnu)) = 0.42.2
-Provides: bundled(crate(windows_i686_msvc)) = 0.42.2
-Provides: bundled(crate(windows_x86_64_gnu)) = 0.42.2
-Provides: bundled(crate(windows_x86_64_gnullvm)) = 0.42.2
-Provides: bundled(crate(windows_x86_64_msvc)) = 0.42.2
-Provides: bundled(crate(winreg)) = 0.10.1
-Provides: bundled(crate(xattr)) = 1.0.0
-Provides: bundled(crate(yaml-rust)) = 0.4.5
-Provides: bundled(crate(yansi)) = 0.5.1
-Provides: bundled(crate(zeroize)) = 1.6.0
-Provides: bundled(crate(zeroize_derive)) = 1.4.1
+BuildRequires:  clang-devel
+BuildRequires:  cryptsetup-devel
+BuildRequires:  device-mapper-devel
+BuildRequires:  golang
+BuildRequires:  openssl-devel >= 3.0.1-12
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  tpm2-tss-devel
 
 %description
 %{summary}.
 
 %prep
-%forgeautosetup
-%if ! 0%{?with_packit}
-tar xvf %{SOURCE2}
-%endif
-%if ! 0%{?with_bundled}
+%autosetup -p1 -n %{name}-rs-%{version}
+
+%if 0%{?rhel}
+%cargo_prep -V 1
+%else
 %cargo_prep
-%else
-mkdir -p .cargo
-cat >.cargo/config << EOF
-[build]
-rustc = "%{__rustc}"
-rustdoc = "%{__rustdoc}"
-%if 0%{?rhel} && !0%{?eln}
-rustflags = %{__global_rustflags_toml}
-%else
-rustflags = "%{__global_rustflags_toml}"
-%endif
-
-[install]
-root = "%{buildroot}%{_prefix}"
- 
-[term]
-verbose = true
- 
-[source.crates-io]
-replace-with = "vendored-sources"
- 
-[source.vendored-sources]
-directory = "vendor"
-EOF
-%endif
-
-%if ! 0%{?with_bundled}
 %generate_buildrequires
-%cargo_generate_buildrequires
+%cargo_generate_buildrequires -a
 %endif
 
 %build
-%if 0%{?rhel} && !0%{?eln}
 %cargo_build \
 -F openssl-kdf/deny_custom
-%else
-%cargo_build
-%endif
-make man
+
+%{?cargo_license_summary}
+%{?cargo_license} > LICENSE.dependencies
 
 %install
 install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-client-linuxapp
@@ -475,53 +59,50 @@ install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-manufact
 install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-owner-onboarding-server
 install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-rendezvous-server
 install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-serviceinfo-api-server
-# duplicates as needed by AIO command
-install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-owner-tool
-install -D -m 0755 -t %{buildroot}%{_libexecdir}/fdo target/release/fdo-admin-tool
 install -D -m 0755 -t %{buildroot}%{_bindir} target/release/fdo-owner-tool
 install -D -m 0755 -t %{buildroot}%{_bindir} target/release/fdo-admin-tool
 install -D -m 0644 -t %{buildroot}%{_unitdir} examples/systemd/*
-# we do not need the rendezvous-info.yml for the AIO command, add everything else
-install -D -m 0644 -t %{buildroot}%{_docdir}/examples examples/config/manufacturing-server.yml
-install -D -m 0644 -t %{buildroot}%{_docdir}/examples examples/config/owner-onboarding-server.yml
-install -D -m 0644 -t %{buildroot}%{_docdir}/examples examples/config/rendezvous-server.yml
-install -D -m 0644 -t %{buildroot}%{_docdir}/examples examples/config/serviceinfo-api-server.yml
+install -D -m 0644 -t %{buildroot}%{_docdir}/fdo examples/config/*
+# duplicates as needed by AIO command so link them
+ln -s %{_bindir}/fdo-owner-tool  %{buildroot}%{_libexecdir}/fdo/fdo-owner-tool
+ln -s %{_bindir}/fdo-admin-tool %{buildroot}%{_libexecdir}/fdo/fdo-admin-tool
 mkdir -p %{buildroot}%{_sysconfdir}/fdo
-# 52fdo
+# Dracut manufacturing service
 install -D -m 0755 -t %{buildroot}%{dracutlibdir}/modules.d/52fdo dracut/52fdo/module-setup.sh
 install -D -m 0755 -t %{buildroot}%{dracutlibdir}/modules.d/52fdo dracut/52fdo/manufacturing-client-generator
 install -D -m 0755 -t %{buildroot}%{dracutlibdir}/modules.d/52fdo dracut/52fdo/manufacturing-client-service
 install -D -m 0755 -t %{buildroot}%{dracutlibdir}/modules.d/52fdo dracut/52fdo/manufacturing-client.service
-# man pages
-install -D -m 0644 -t %{buildroot}%{_mandir}/man1 %{rpmdocsdir}/*.1
 
 %package -n fdo-init
 Summary: dracut module for device initialization
+License: %combined_license
 Requires: openssl-libs >= 3.0.1-12
+Requires: dracut
 %description -n fdo-init
 %{summary}
 
 %files -n fdo-init
-%license LICENSE
-%{_mandir}/man1/fdo-init.1*
-%{dracutlibdir}/modules.d/52fdo/*
+%license LICENSE LICENSE.dependencies
+%{dracutlibdir}/modules.d/52fdo/
 %{_libexecdir}/fdo/fdo-manufacturing-client
 
 %package -n fdo-owner-onboarding-server
 Summary: FDO Owner Onboarding Server implementation
+License: %combined_license
 Requires: openssl-libs >= 3.0.1-12
 %description -n fdo-owner-onboarding-server
 %{summary}
 
 %files -n fdo-owner-onboarding-server
-%license LICENSE
-%{_mandir}/man1/fdo-owner-onboarding-server.1*
+%license LICENSE LICENSE.dependencies
 %{_libexecdir}/fdo/fdo-owner-onboarding-server
 %{_libexecdir}/fdo/fdo-serviceinfo-api-server
-%{_docdir}/examples/owner-onboarding-server.yml
-%{_docdir}/examples/serviceinfo-api-server.yml
-%{_unitdir}/fdo-owner-onboarding-server.service
+%dir %{_docdir}/fdo
+%{_docdir}/fdo/device_specific_serviceinfo.yml
+%{_docdir}/fdo/serviceinfo-api-server.yml
+%{_docdir}/fdo/owner-onboarding-server.yml
 %{_unitdir}/fdo-serviceinfo-api-server.service
+%{_unitdir}/fdo-owner-onboarding-server.service
 
 %post -n fdo-owner-onboarding-server
 %systemd_post fdo-owner-onboarding-server.service
@@ -529,7 +110,7 @@ Requires: openssl-libs >= 3.0.1-12
 
 %preun -n fdo-owner-onboarding-server
 %systemd_preun fdo-owner-onboarding-server.service
-%systemd_preun fdo-serviceinfo-api-server.service
+%systemd_post fdo-serviceinfo-api-server.service
 
 %postun -n fdo-owner-onboarding-server
 %systemd_postun_with_restart fdo-owner-onboarding-server.service
@@ -537,14 +118,15 @@ Requires: openssl-libs >= 3.0.1-12
 
 %package -n fdo-rendezvous-server
 Summary: FDO Rendezvous Server implementation
+License: %combined_license
 %description -n fdo-rendezvous-server
 %{summary}
 
 %files -n fdo-rendezvous-server
-%license LICENSE
-%{_mandir}/man1/fdo-rendezvous-server.1*
+%license LICENSE LICENSE.dependencies
 %{_libexecdir}/fdo/fdo-rendezvous-server
-%{_docdir}/examples/rendezvous-server.yml
+%dir %{_docdir}/fdo
+%{_docdir}/fdo/rendezvous-*.yml
 %{_unitdir}/fdo-rendezvous-server.service
 
 %post -n fdo-rendezvous-server
@@ -558,15 +140,16 @@ Summary: FDO Rendezvous Server implementation
 
 %package -n fdo-manufacturing-server
 Summary: FDO Manufacturing Server implementation
+License: %combined_license
 Requires: openssl-libs >= 3.0.1-12
 %description -n fdo-manufacturing-server
 %{summary}
 
 %files -n fdo-manufacturing-server
-%license LICENSE
-%{_mandir}/man1/fdo-manufacturing-server.1*
+%license LICENSE LICENSE.dependencies
 %{_libexecdir}/fdo/fdo-manufacturing-server
-%{_docdir}/examples/manufacturing-server.yml
+%dir %{_docdir}/fdo
+%{_docdir}/fdo/manufacturing-server.yml
 %{_unitdir}/fdo-manufacturing-server.service
 
 %post -n fdo-manufacturing-server
@@ -580,16 +163,17 @@ Requires: openssl-libs >= 3.0.1-12
 
 %package -n fdo-client
 Summary: FDO Client implementation
+License: %combined_license
 Requires: openssl-libs >= 3.0.1-12
 Requires: clevis
 Requires: clevis-luks
+Requires: clevis-pin-tpm2
 Requires: cryptsetup
 %description -n fdo-client
 %{summary}
 
 %files -n fdo-client
-%license LICENSE
-%{_mandir}/man1/fdo-client.1*
+%license LICENSE LICENSE.dependencies
 %{_libexecdir}/fdo/fdo-client-linuxapp
 %{_unitdir}/fdo-client-linuxapp.service
 
@@ -604,33 +188,33 @@ Requires: cryptsetup
 
 %package -n fdo-owner-cli
 Summary: FDO Owner tools implementation
+License: %combined_license
 %description -n fdo-owner-cli
 %{summary}
 
 %files -n fdo-owner-cli
-%license LICENSE
-%{_mandir}/man1/fdo-owner-cli.1*
+%license LICENSE LICENSE.dependencies
 %{_bindir}/fdo-owner-tool
 %{_libexecdir}/fdo/fdo-owner-tool
 
 %package -n fdo-admin-cli
 Summary: FDO admin tools implementation
-Requires: fdo-manufacturing-server
-Requires: fdo-init
-Requires: fdo-client
-Requires: fdo-rendezvous-server
-Requires: fdo-owner-onboarding-server
-Requires: fdo-owner-cli
+License: %combined_license
+Requires: fdo-manufacturing-server = %{version}-%{release}
+Requires: fdo-init = %{version}-%{release}
+Requires: fdo-client = %{version}-%{release}
+Requires: fdo-rendezvous-server = %{version}-%{release}
+Requires: fdo-owner-onboarding-server = %{version}-%{release}
+Requires: fdo-owner-cli = %{version}-%{release}
 %description -n fdo-admin-cli
 %{summary}
 
 %files -n fdo-admin-cli
-%license LICENSE
-%{_mandir}/man1/fdo-admin-cli.1*
-%dir %{_sysconfdir}/fdo
+%license LICENSE LICENSE.dependencies
 %{_bindir}/fdo-admin-tool
 %{_libexecdir}/fdo/fdo-admin-tool
 %{_unitdir}/fdo-aio.service
+%dir %{_sysconfdir}/fdo
 
 %post -n fdo-admin-cli
 %systemd_post fdo-aio.service
@@ -642,26 +226,49 @@ Requires: fdo-owner-cli
 %systemd_postun_with_restart fdo-aio.service
 
 %changelog
-* Wed Feb 15 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.8-1
-- Update to 0.4.8
+* Fri Jun 23 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.10-1
+- Update to 0.4.10
+
+* Wed Jun 14 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.9-5
+- More spec updates
+
+* Wed Jun 14 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.9-4
+- Add patch for libcryptsetup-rs 0.8 API changes
+
+* Tue Jun 13 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.9-3
+- Updates for licenses
+
+* Tue May 30 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.9-2
+- Review feedback
+- Patch for libcryptsetup-rs 0.7
+
+* Thu May 11 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.9-1
+- Update to 0.4.9
+
+* Mon Feb 20 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.7-3
+- Fix services start
+
+* Wed Feb 15 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.7-2
+- Upstream fix for rhbz#2168089
 
 * Wed Nov 30 2022 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.7-1
 - Update to 0.4.7
+- Package updates and cleanup
 
-* Thu Oct 06 2022 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.6-1
-- Update to 0.4.6
+* Tue Mar 29 2022 Antonio Murdaca <runcom@linux.com> - 0.4.5-1
+- bump to 0.4.5
 
-* Tue Mar 15 2022 Antonio Murdaca <runcom@linux.com> - 0.4.5-1
-- Rebase to 0.4.5
+* Mon Feb 28 2022 Antonio Murdaca <runcom@linux.com> - 0.4.0-2
+- fix runtime requirements to use openssl-libs and not -devel
 
-* Thu Feb 24 2022 Patrick Uiterwijk <patrick@puiterwijk.org> - 0.4.0-1
-- Rebase to 0.4.0
+* Thu Feb 24 2022 Antonio Murdaca <runcom@linux.com> - 0.4.0-1
+- upgrade to 0.4.0
 
-* Tue Feb 1 2022 Patrick Uiterwijk <puiterwijk@redhat.com> - 0.3.0-1
-- Rebase to 0.3.0
+* Tue Feb 01 2022 Antonio Murdaca <runcom@linux.com> - 0.3.0-1
+- bump to 0.3.0
 
-* Fri Dec 10 2021 Patrick Uiterwijk <puiterwijk@redhat.com> - 0.2.0-1
-- Rebase to 0.2.0
+* Tue Jan 11 2022 Antonio Murdaca <runcom@linux.com> - 0.2.0-2
+- use patched vendor w/o win files and rename license
 
-* Tue Oct 5 2021 Antonio Murdaca <amurdaca@redhat.com> - 0.1.0-1
-- initial release
+* Mon Dec 13 2021 Antonio Murdaca <runcom@linux.com> - 0.2.0-1
+- import fido-device-onboard

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -3,7 +3,7 @@
 %global combined_license Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache 2.0) AND ISC AND MIT AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (Apache-2.0 OR MIT OR Zlib) AND MPL-2.0 AND (Unlicense OR MIT)
 
 Name:           fido-device-onboard
-Version:        0.4.10
+Version:        0.4.11
 Release:        1%{?dist}
 Summary:        A rust implementation of the FIDO Device Onboard Specification
 License:        BSD-3-Clause
@@ -12,8 +12,6 @@ URL:            https://github.com/fedora-iot/fido-device-onboard-rs
 Source0:        %{url}/archive/v%{version}/%{name}-rs-%{version}.tar.gz
 # See make-vendored-tarfile.sh in upstream repo
 Source1:        %{name}-rs-%{version}-vendor-patched.tar.xz
-# From upstream
-Patch0:         0001-chore-update-libcryptsetup-rs-to-0.8.patch
 
 # Because nobody cares
 ExcludeArch: %{ix86}
@@ -226,6 +224,9 @@ Requires: fdo-owner-cli = %{version}-%{release}
 %systemd_postun_with_restart fdo-aio.service
 
 %changelog
+* Mon Jul 03 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.11-1
+- Update to 0.4.11
+
 * Fri Jun 23 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.10-1
 - Update to 0.4.10
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10.55"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-store = { path = "../store", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-store = { path = "../store", version = "0.4.11" }
 aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -12,7 +12,7 @@
 
 #define FDO_DATA_MAJOR 0
 #define FDO_DATA_MINOR 4
-#define FDO_DATA_PATCH 10
+#define FDO_DATA_PATCH 11
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -16,9 +16,9 @@ tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
 passwd = "0.0.1"
 rand = "0.8.4"
-tss-esapi = "7.2"
+tss-esapi = { version = "7.2", features = ["generate-bindings"] }
 regex = "1.3.7"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ log = "0.4"
 hex = "0.4"
 serde_yaml = "0.9"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.11", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.11", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -14,11 +14,11 @@ openssl = "0.10.55"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
-tss-esapi = "7.2"
+tss-esapi = { version = "7", features = ["generate-bindings"] }
 
-fdo-util = { path = "../util", version = "0.4.10" }
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.11" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["client"] }
 
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.10" }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.11" }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,7 +16,7 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server"] }
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-store = { path = "../store", version = "0.4.10", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.10" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-store = { path = "../store", version = "0.4.11", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.11" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fdo-store"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
 
 config = "0.13.3"
 futures = "0.3"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ glob = "0.3.1"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.10" }
-fdo-store = { path = "../store", version = "0.4.10" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.10", features = ["server", "client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
+fdo-store = { path = "../store", version = "0.4.11" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["server", "client"] }
 serde_yaml = "0.9"
 serde_cbor = "0.11"
 serde_json = "1"


### PR DESCRIPTION
This updates the spec to the latest in Fedora and preps for 0.4.11