### PR TITLE
Dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,12 @@ jobs:
         with:
           toolchain: stable
       - name: Build
-        run: cargo build
+        run: cargo build --workspace
       - name: Run tests
         env:
           FDO_PRIVILEGED: true
           PER_DEVICE_SERVICEINFO: false
-        run: cargo test
+        run: cargo test --workspace
       - name: Check aio
         run: |
           mkdir aio-dir/
@@ -167,4 +167,4 @@ jobs:
       - name: Build devcontainer
         run: devcontainer build --image-name devcontainer-fdo-rs .
       - name: Test building in devcontainer
-        run: docker run --rm -v `pwd`:/code:z --workdir /code --user root devcontainer-fdo-rs cargo build --verbose
+        run: docker run --rm -v `pwd`:/code:z --workdir /code --user root devcontainer-fdo-rs cargo build --workspace --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_yaml",
- "tera",
  "time",
  "tokio",
 ]
@@ -805,7 +804,6 @@ dependencies = [
  "fdo-util",
  "libcryptsetup-rs",
  "log",
- "logtest",
  "nix",
  "openssl",
  "passwd",
@@ -840,7 +838,6 @@ dependencies = [
  "ciborium",
  "hex",
  "http",
- "hyper",
  "log",
  "maplit",
  "num-derive",
@@ -894,10 +891,8 @@ dependencies = [
  "hex",
  "log",
  "openssl",
- "passwd",
  "rand",
  "regex",
- "sys-info",
  "tokio",
  "tss-esapi",
 ]
@@ -1006,15 +1001,12 @@ name = "fdo-store"
 version = "0.4.11"
 dependencies = [
  "async-trait",
- "config",
  "fdo-data-formats",
- "futures",
  "log",
  "serde",
  "serde_cbor",
  "thiserror",
  "time",
- "tokio",
  "xattr",
 ]
 
@@ -1653,19 +1645,6 @@ name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
-dependencies = [
- "value-bag",
-]
-
-[[package]]
-name = "logtest"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e43a8657c1d64516dcc9db8ca03826a4aceaf89d5ce1b37b59f6ff0e43026"
-dependencies = [
- "lazy_static",
- "log",
-]
 
 [[package]]
 name = "maplit"
@@ -3221,12 +3200,6 @@ checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "value-bag"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,6 @@ dependencies = [
  "rand",
  "secrecy",
  "serde_bytes",
- "sha-crypt",
  "sys-info",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,20 @@ members = [
 
     "integration-tests",
 ]
+
+default-members = [
+    "libfdo-data",
+    "data-formats",
+    "http-wrapper",
+    "store",
+    "util",
+
+    "client-linuxapp",
+    "owner-onboarding-server",
+    "owner-tool",
+    "rendezvous-server",
+    "manufacturing-server",
+    "manufacturing-client",
+    "serviceinfo-api-server",
+    "admin-tool",
+]

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -15,7 +15,6 @@ time = "0.3"
 clap = { version = "4.2", features = ["derive"] }
 futures = "0.3"
 reqwest = "0.11"
-tera = "1"
 serde = "1"
 serde_yaml = "0.9"
 pretty_env_logger = "0.4"

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -22,7 +22,6 @@ secrecy = "0.8"
 devicemapper = "0.33"
 openssl = "0.10.55"
 sha-crypt = "0.5.0"
-logtest = "2.0.0"
 
 fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
 fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["client"] }

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -21,7 +21,6 @@ libcryptsetup-rs = { version = "0.8.0", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.33"
 openssl = "0.10.55"
-sha-crypt = "0.5.0"
 
 fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
 fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.11", features = ["client"] }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -27,7 +27,6 @@ tss-esapi = { version = "7.2", features = ["generate-bindings"] }
 byteorder = "1"
 
 http = "0.2"
-hyper = "0.14"
 
 openssl-kdf = { version = "0.4.1", features = ["allow_custom"] }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/di_diun.rs"
 name = "to-tests"
 path = "tests/to.rs"
 
-[dependencies]
+[dev-dependencies]
 anyhow = "1"
 hex = "0.4"
 tempfile = "3"

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -1,6 +1,5 @@
 mod common;
 use std::env;
-#[allow(unused_imports)]
 use std::{fs, io::Write, process::Command, time::Duration};
 
 use common::{Binary, LogSide, TestContext};
@@ -412,7 +411,6 @@ ssh-ed25519 sshkey_default user@example.com
                 false,
                 "Password not created during onboarding"
             );
-            assert!(sha256_check("testpassword", &test_user.password).is_ok());
         }
     } else {
         L.l("Skipped create initial user validation

--- a/integration-tests/tests/service_info.rs
+++ b/integration-tests/tests/service_info.rs
@@ -289,7 +289,6 @@ ssh-ed25519 sshkey_default user@example.com
                 false,
                 "Password not created during onboarding"
             );
-            assert!(sha256_check("testpassword", &test_user.password).is_ok());
         }
     } else {
         L.l("Skipped create initial user validation

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -13,8 +13,6 @@ hex = "0.4"
 log = "0.4"
 openssl = "0.10.55"
 tokio = { version = "1", features = ["full"] }
-sys-info = "0.9"
-passwd = "0.0.1"
 rand = "0.8.4"
 tss-esapi = { version = "7.2", features = ["generate-bindings"] }
 regex = "1.3.7"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -9,13 +9,10 @@ edition = "2018"
 [dependencies]
 fdo-data-formats = { path = "../data-formats", version = "0.4.11" }
 
-config = "0.13.3"
-futures = "0.3"
 thiserror = "1"
 async-trait = "0.1"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-tokio = "1"
 time = "0.3"
 
 # feature-specific dependencies


### PR DESCRIPTION
- marks all dependencies in `integration-tests` as dev-dependencies
- changes the Cargo.toml workspace so that by default a `cargo build` does *not* build the integration tests, they will be built if we specify `cargo build --workspace`, meaning that the whole workspace needs to be built
- removes unused dependecies
- removes the `sha-crypt` dependency and uses `openssl` directly. This requires to update the tests since using openssl like this updates the salt of the password every time, whereas with `sha-crypt` we did not do that.