### PR TITLE
[WIP] chore: Update e2e tests to check flow with multiple ssh keys per user

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -274,11 +274,11 @@ async fn perform_to1(
         Ok(token) => token,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(client, e.borrow()).await;
+                send_client_error(client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(client, e.borrow()).await;
+                send_client_error(client, &e).await;
                 bail!(e.error);
             }
         },
@@ -289,11 +289,11 @@ async fn perform_to1(
         Ok(to1d) => Ok(to1d),
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(client, e.borrow()).await;
+                send_client_error(client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(client, e.borrow()).await;
+                send_client_error(client, &e).await;
                 bail!(e.error);
             }
         },
@@ -861,11 +861,11 @@ async fn perform_to2(
         Ok(nonce5) => nonce5,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -883,11 +883,11 @@ async fn perform_to2(
             Ok(values) => values,
             Err(e) => match e {
                 ClientError::Request(e) => {
-                    send_client_error(&mut client, e.borrow()).await;
+                    send_client_error(&mut client, &e).await;
                     bail!(e.error);
                 }
                 ClientError::Response(e) => {
-                    send_client_error(&mut client, e.borrow()).await;
+                    send_client_error(&mut client, &e).await;
                     bail!(e.error);
                 }
             },
@@ -897,11 +897,11 @@ async fn perform_to2(
         Ok(nonce6) => nonce6,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -919,11 +919,11 @@ async fn perform_to2(
         Ok(payload) => payload,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -941,11 +941,11 @@ async fn perform_to2(
         Ok(values) => values,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -956,11 +956,11 @@ async fn perform_to2(
         Ok(nonce7) => nonce7,
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -980,11 +980,11 @@ async fn perform_to2(
         Ok(_) => (),
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -995,11 +995,11 @@ async fn perform_to2(
         Ok(_) => (),
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },
@@ -1049,11 +1049,11 @@ async fn perform_to2(
         Ok(_) => Ok(reboot_required),
         Err(e) => match e {
             ClientError::Request(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
             ClientError::Response(e) => {
-                send_client_error(&mut client, e.borrow()).await;
+                send_client_error(&mut client, &e).await;
                 bail!(e.error);
             }
         },

--- a/integration-tests/templates/serviceinfo-api-server.yml.j2
+++ b/integration-tests/templates/serviceinfo-api-server.yml.j2
@@ -10,7 +10,8 @@ service_info:
     username: {{ user }}
     password: {{ password }}
     sshkeys:
-    - {{ sshkey }}
+    - {{ sshkey1 }}
+    - {{ sshkey2 }}
   files:
   - path: /etc/hosts
     permissions: 644

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -807,7 +807,8 @@ impl<'a> TestServerConfigurator<'a> {
                         "user",
                         users::get_current_username().unwrap().to_str().unwrap(),
                     );
-                    cfg.insert("sshkey", "ssh-ed25519 sshkey_default user@example.com");
+                    cfg.insert("sshkey1", "ssh-ed25519 sshkey_default user@example.com");
+                    cfg.insert("sshkey2", "ssh-ed25519 sshkey_default user@example2.com");
                     cfg.insert("password", "testpassword");
                 } else {
                     L.l("per_device_serviceinfo is set, using device specific values");
@@ -815,7 +816,8 @@ impl<'a> TestServerConfigurator<'a> {
                         "user",
                         users::get_current_username().unwrap().to_str().unwrap(),
                     );
-                    cfg.insert("sshkey", "ssh-ed25519 sshkey_per_device user@example.com");
+                    cfg.insert("sshkey1", "ssh-ed25519 sshkey_per_device user@example.com");
+                    cfg.insert("sshkey2", "ssh-ed25519 sshkey_per_device user@example2.com");
                     cfg.insert("password", "testpassword");
                 }
 

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -394,6 +394,9 @@ where
         "
 # These keys are installed by FIDO Device Onboarding
 ssh-ed25519 sshkey_default user@example.com
+# End of FIDO Device Onboarding keys\n
+# These keys are installed by FIDO Device Onboarding
+ssh-ed25519 sshkey_default user@example2.com
 # End of FIDO Device Onboarding keys
 "
     );
@@ -649,6 +652,9 @@ where
         "
 # These keys are installed by FIDO Device Onboarding
 ssh-ed25519 sshkey_per_device user@example.com
+# End of FIDO Device Onboarding keys\n
+# These keys are installed by FIDO Device Onboarding
+ssh-ed25519 sshkey_per_device user@example2.com
 # End of FIDO Device Onboarding keys
 "
     );

--- a/integration-tests/tests/service_info.rs
+++ b/integration-tests/tests/service_info.rs
@@ -273,6 +273,10 @@ where
 # These keys are installed by FIDO Device Onboarding
 ssh-ed25519 sshkey_default user@example.com
 # End of FIDO Device Onboarding keys
+
+# These keys are installed by FIDO Device Onboarding
+ssh-ed25519 sshkey_default user@example2.com
+# End of FIDO Device Onboarding keys
 "
     );
     if ci {

--- a/integration-tests/tests/to.rs
+++ b/integration-tests/tests/to.rs
@@ -265,6 +265,10 @@ async fn test_to_impl(
 # These keys are installed by FIDO Device Onboarding
 ssh-ed25519 sshkey_default user@example.com
 # End of FIDO Device Onboarding keys
+
+# These keys are installed by FIDO Device Onboarding
+ssh-ed25519 sshkey_default user@example2.com
+# End of FIDO Device Onboarding keys
 "
     );
 


### PR DESCRIPTION
This PR attempts to test if a user can be created with multiple ssh keys associated with it.

- Updates tests to check user creation with multiple ssh keys.
- Fixed clippy `using .borrow() on double reference` warnings.

closes #507 