### PR TITLE
fix: drop unused sha-crypt dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,7 +1485,6 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "sha-crypt",
  "shadow",
  "tempfile",
  "tera",
@@ -2588,18 +2581,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
-]
-
-[[package]]
-name = "sha-crypt"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e79009728d8311d42d754f2f319a975f9e38f156fd5e422d2451486c78b286"
-dependencies = [
- "base64ct",
- "rand",
- "sha2 0.10.6",
- "subtle",
 ]
 
 [[package]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -36,7 +36,6 @@ passwd = "0.0.1"
 shadow = "0.0.1"
 pem = "2.0"
 users = "0.11.0"
-sha-crypt = "0.5.0"
 
 fdo-data-formats = { path = "../data-formats" }
 fdo-util = { path = "../util" }


### PR DESCRIPTION
The use of sha-crypt was dropped with commit 8d1d1b2 but one of the Cargo.toml updates was missed so drop it there and update Cargo.lock to match.

Fixes: 8d1d1b2 ("chore: replace sha-crypt with openssl process calls")