### PR TITLE
feat: replace shadow and passwd crates with our built-in functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,6 @@ dependencies = [
  "log",
  "nix",
  "openssl",
- "passwd",
  "rand",
  "secrecy",
  "serde_bytes",
@@ -1476,7 +1475,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "openssl",
- "passwd",
  "paste",
  "pem",
  "pretty_assertions",
@@ -1485,7 +1483,6 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "shadow",
  "tempfile",
  "tera",
  "tokio",
@@ -1927,15 +1924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex",
-]
-
-[[package]]
-name = "passwd"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5499366e9469e62340d8c66d31b6c545483a28a41c97d82210703188bcd2f473"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2616,15 +2604,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "shadow"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaa1dbf13cc052b53af59e70dd467e8e94d6abf8d0eac1f1d15d3e165973b86"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -12,7 +12,6 @@ log = "0.4"
 tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
 serde_bytes = "0.11"
-passwd = "0.0.1"
 rand = "0.8.4"
 nix = "0.26"
 uuid = "1.3"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -32,8 +32,6 @@ serde_cbor = "0.11"
 serde_json = "1.0"
 pretty_assertions = "1.0.0"
 paste = "1.0"
-passwd = "0.0.1"
-shadow = "0.0.1"
 pem = "2.0"
 users = "0.11.0"
 

--- a/integration-tests/tests/service_info.rs
+++ b/integration-tests/tests/service_info.rs
@@ -1,4 +1,5 @@
 mod common;
+use fdo_util::passwd_shadow;
 use std::env;
 #[allow(unused_imports)]
 use std::{fs, io::Write, process::Command, time::Duration};
@@ -280,17 +281,21 @@ ssh-ed25519 sshkey_default user@example2.com
     if ci {
         L.l("Running create initial user validation");
         pretty_assertions::assert_eq!(
-            passwd::Passwd::from_name(new_user).is_some(),
+            passwd_shadow::is_user_in_passwd(new_user)?,
             true,
             "User: {} is not created during onboarding",
             &new_user
         );
-        if let Some(test_user) = shadow::Shadow::from_name(new_user) {
-            pretty_assertions::assert_eq!(
-                test_user.password.is_empty(),
-                false,
-                "Password not created during onboarding"
-            );
+
+        match passwd_shadow::get_user_passwd(new_user) {
+            Ok(pass) => {
+                pretty_assertions::assert_eq!(
+                    pass.is_empty(),
+                    false,
+                    "Password not created during onboarding"
+                );
+            }
+            Err(e) => bail!(e),
         }
     } else {
         L.l("Skipped create initial user validation

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod device_credential_locations;
 pub mod device_identification;
+pub mod passwd_shadow;
 pub mod servers;
 
 pub fn maybe_print_version(

--- a/util/src/passwd_shadow.rs
+++ b/util/src/passwd_shadow.rs
@@ -1,0 +1,42 @@
+use anyhow::{bail, Result};
+use std::fs;
+
+/// Checks whether an entry for the given user name 'username' exists in
+/// /etc/passwd
+pub fn is_user_in_passwd(username: &str) -> Result<bool> {
+    for line in fs::read_to_string("/etc/passwd")?.lines() {
+        let contents: Vec<&str> = line.split(':').collect();
+        if !contents.is_empty() && contents[0] == username {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Returns the uid, gid and home of the given user or Error if user does not
+/// exist in /etc/passwd.
+pub fn get_user_uid_gid_home(username: &str) -> Result<(u32, u32, String)> {
+    for line in fs::read_to_string("/etc/passwd")?.lines() {
+        let contents: Vec<&str> = line.split(':').collect();
+        if !contents.is_empty() && contents[0] == username {
+            return Ok((
+                contents[2].parse::<u32>()?,
+                contents[3].parse::<u32>()?,
+                contents[5].to_string(),
+            ));
+        }
+    }
+    bail!("User {username} not found")
+}
+
+/// Returns the password of a given user. Errors if the user does not exist
+/// in /etc/shadow.
+pub fn get_user_passwd(username: &str) -> Result<String> {
+    for line in fs::read_to_string("/etc/shadow")?.lines() {
+        let contents: Vec<&str> = line.split(':').collect();
+        if !contents.is_empty() && contents[0] == username {
+            return Ok(contents[1].to_string());
+        }
+    }
+    bail!("User {username} not found")
+}


### PR DESCRIPTION
This removes the dependencies on shadow and passwd from the project since we can accomplish the same functionality reading the /etc/shadow and /etc/passwd files.