### PR TITLE
fix: use J option (xz) instead of j (bzip2) for compression

### DIFF
--- a/make-vendored-tarfile.sh
+++ b/make-vendored-tarfile.sh
@@ -11,4 +11,4 @@ rm -rf winapi-x86_64-pc-windows-gnu/lib/*
 rm -rf winapi-i686-pc-windows-gnu/lib/*
 rm -rf vcpkg/test-data
 popd #vendor
-tar cjf fido-device-onboard-rs-$ver-vendor-patched.tar.xz vendor/
+tar cJf fido-device-onboard-rs-$ver-vendor-patched.tar.xz vendor/


### PR DESCRIPTION
We are setting a .tar.xz extension so we should build a .tar.xz instead of a bzip2. This sets such option in `make-vendored-tarfile.sh`