### PR TITLE
fix(spec): add both clients as fdo-admin-cli's Requires

### DIFF
--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -238,6 +238,8 @@ Requires: fdo-manufacturing-server = %{version}-%{release}
 Requires: fdo-rendezvous-server = %{version}-%{release}
 Requires: fdo-owner-onboarding-server = %{version}-%{release}
 Requires: fdo-owner-cli = %{version}-%{release}
+Requires: fdo-client = %{version}-%{release}
+Requires: fdo-init = %{version}-%{release}
 %description -n fdo-admin-cli
 %{summary}
 


### PR DESCRIPTION
We removed the clients from the Requires list so the `fdo-aio.service` can't start. This fixes that.

Fixes rhbz#2230537