### PR TITLE
chore: fixup paths for selinux

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -446,10 +446,10 @@ service_info:
     sshkeys:
     - "testkey"
   files:
-  - path: /device/etc/hosts
+  - path: /var/lib/fdo/service-info-api/files/hosts
     permissions: 644
     source_path: /server/local/etc/hosts
-  - path: /device/etc/resolv.conf
+  - path: /var/lib/fdo/service-info-api/files/resolv.conf
     source_path: /server/local/etc/resolv.conf
   commands:
   - command: ls
@@ -493,7 +493,7 @@ Where:
   - `files`: [OPTIONAL] transfers files to a device.
     - `path`: destination path.
     - `permissions`: permissions to set on the file.
-    - `source_path`: source file path.
+    - `source_path`: source file path, must be a file under `/var/lib/fdo/`.
   - `commands`: [OPTIONAL] executes the given list of commands on the device.
       - `command`: command to execute.
       - `args`: list of arguments for the command.

--- a/data-formats/src/messages/v11/diun.rs
+++ b/data-formats/src/messages/v11/diun.rs
@@ -54,7 +54,7 @@ impl Message for Connect {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to0.rs
+++ b/data-formats/src/messages/v11/to0.rs
@@ -26,7 +26,7 @@ impl Message for Hello {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to1.rs
+++ b/data-formats/src/messages/v11/to1.rs
@@ -37,7 +37,7 @@ impl Message for HelloRV {
     }
 
     fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to2.rs
+++ b/data-formats/src/messages/v11/to2.rs
@@ -75,7 +75,7 @@ impl Message for HelloDevice {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/examples/config/serviceinfo-api-server.yml
+++ b/examples/config/serviceinfo-api-server.yml
@@ -11,10 +11,10 @@ service_info:
     sshkeys:
     - "testkey"
   files:
-  - path: /device/etc/hosts
+  - path: /var/lib/fdo/service-info-api/files/hosts
     permissions: 644
     source_path: /server/local/etc/hosts
-  - path: /device/etc/resolv.conf
+  - path: /var/lib/fdo/service-info-api/files/resolv.conf
     source_path: /server/local/etc/resolv.conf
   commands:
   - command: ls


### PR DESCRIPTION
Using the service-info-api server with selinux requires us to put anything we want to send to the device under /var/lib/fdo as that directory, and its files, will now get the correct selinux label. The previous approach opens up for security issues by leaving the process basically accessing the whole host.