### PR TITLE
fix(data-formats): fixes redundant pattern matching

### DIFF
--- a/data-formats/src/messages/v11/diun.rs
+++ b/data-formats/src/messages/v11/diun.rs
@@ -54,7 +54,7 @@ impl Message for Connect {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to0.rs
+++ b/data-formats/src/messages/v11/to0.rs
@@ -26,7 +26,7 @@ impl Message for Hello {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to1.rs
+++ b/data-formats/src/messages/v11/to1.rs
@@ -37,7 +37,7 @@ impl Message for HelloRV {
     }
 
     fn is_valid_previous_message(message_type: Option<crate::constants::MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {

--- a/data-formats/src/messages/v11/to2.rs
+++ b/data-formats/src/messages/v11/to2.rs
@@ -75,7 +75,7 @@ impl Message for HelloDevice {
     }
 
     fn is_valid_previous_message(message_type: Option<MessageType>) -> bool {
-        matches!(message_type, None)
+        message_type.is_none()
     }
 
     fn encryption_requirement() -> Option<EncryptionRequirement> {


### PR DESCRIPTION
There has been a new clippy update, which has triggered new warnings, this fixes those warnings to unblock PRs.