### PR TITLE
docs(howto): fix config file names

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -9,11 +9,11 @@
   - How to extend an OV with the Owner's Certificate
   - How to convert a PEM (plain-text) format OV to a COSE (binary) format OV
 - Configuration Files
-  - `manufacturing_server.yml`
-    - `rendezvous_info` field and `rendezvous_info.yml`
-  - `owner_onboarding_server.yml`
-  - `rendezvous_server.yml`
-  - `serviceinfo_api_server.yml`
+  - `manufacturing-server.yml`
+    - `rendezvous_info` field and `rendezvous-info.yml`
+  - `owner-onboarding-server.yml`
+  - `rendezvous-server.yml`
+  - `serviceinfo-api-server.yml`
 - How to run the servers:
   - Manufacturing Server
   - Owner Onboarding Server
@@ -102,7 +102,7 @@ seen in [How To Generate Keys and
 Certificates](#how-to-generate-keys-and-certificates) and the argument for
 `--rendezvous-info` is a YAML file containing a list of contact information for the
 different Rendezvous Servers (see [Configuration
-Files/rendezvous_info.yml](#rendezvous_info-field-and-rendezvous_infoyml)).
+Files/rendezvous-info.yml](#rendezvous_info-field-and-rendezvous-infoyml)).
 
 ```bash
   $ fdo-owner-tool initialize-device \
@@ -228,7 +228,7 @@ directory of this project.
 - When a field is required but its sub-fields are all optional you may put a
   null value (`~`) there.
 
-### `manufacturing_server.yml`
+### `manufacturing-server.yml`
 
 The most up-to-date configuration settings will be on [util/src/servers/configuration/manufacturing_server.rs](https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/util/src/servers/configuration/manufacturing_server.rs).
 
@@ -323,16 +323,16 @@ Where:
   - `owner_cert_path`: [OPTIONAL] path to the Owner's certificate of this
     Manufacturing server.
 
-#### `rendezvous_info` field and `rendezvous_info.yml`
+#### `rendezvous_info` field and `rendezvous-info.yml`
 
 The `rendezvous_info` field was previously named `rendezvous_info_path`, which
 instead of containing a list of contact methods to reach different Rendezvous
-Servers it contained the path to a configuration file (`rendezvous_info.yml`)
+Servers it contained the path to a configuration file (`rendezvous-info.yml`)
 that had this same info.
 
 If you are using the `fdo-owner-tool` to initialize a device you will need to
-pass a `rendezvous_info.yml` YAML file (not to be confused with the
-`rendezvous_server.yml`) as one of the configuration parameters.
+pass a `rendezvous-info.yml` YAML file (not to be confused with the
+`rendezvous-server.yml`) as one of the configuration parameters.
 
 ```yml
 ---
@@ -346,10 +346,10 @@ pass a `rendezvous_info.yml` YAML file (not to be confused with the
   protocol: http
 ```
 
-The fields of this `rendezvous_info.yml` file are the same ones that can be
-found in the `rendezvous_info` field of the `manufacturing_server.yml`.
+The fields of this `rendezvous-info.yml` file are the same ones that can be
+found in the `rendezvous_info` field of the `manufacturing-server.yml`.
 
-### `owner_onboarding_server.yml`
+### `owner-onboarding-server.yml`
 
 ```yml
 ---
@@ -404,7 +404,7 @@ Where:
 - `report_to_rendezvous_endpoint_enabled`: whether reporting to the Rendezvous
   Server is enabled or not, boolean.
 
-### `rendezvous_server.yml`
+### `rendezvous-server.yml`
 
 ```yml
 ---
@@ -430,7 +430,7 @@ Where:
   TO1 protocols (default 2592000).
 - `bind`: IP address and port that the Rendezvous Server will take.
 
-### `serviceinfo_api_server.yml`
+### `serviceinfo-api-server.yml`
 
 ```yml
 ---
@@ -529,9 +529,9 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
    certificate and the Device's private key and certificate.
 
 2. Configure `manufacturing-server.yml`, see [Configuration
-   Files/manufacturing_server.yml](#manufacturing_serveryml) and place it either in
+   Files/manufacturing-server.yml](#manufacturing-serveryml) and place it either in
    `/usr/share/fdo`, `/etc/fdo/` or
-   `/etc/fdo/manufacturing-serverr.conf.d/`. The paths will be checked in that
+   `/etc/fdo/manufacturing-server.conf.d/`. The paths will be checked in that
    same order.
 
 3. Execute `fdo-manufacturing-server` or run it as a service, see sample
@@ -544,7 +544,7 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
    keys and certificates](#how-to-generate-keys-and-certificates).
 
 2. Configure `owner-onboarding-server.yml`, see [Configuration
-   Files/owner_onboarding_server.yml](#owner_onboarding_serveryml) and place it
+   Files/owner-onboarding-server.yml](#owner-onboarding-serveryml) and place it
    either in `/usr/share/fdo`, `/etc/fdo/` or
    `/etc/fdo/owner-onboarding-server.conf.d/`. The paths will be checked in
    that same order.
@@ -559,7 +559,7 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
    Rename the generated OV to its Device GUID (see [How to get information about an
    OV](#how-to-get-information-about-an-ov) to identify its Device GUID) and
    store it in the path given to the `ownership_voucher_store_driver` field in
-   the `owner_onboarding_server.yml` of the previous step.
+   the `owner-onboarding-server.yml` of the previous step.
 
 4. Execute `fdo-owner-onboarding-server` or run it as a service, see sample
    file in [examples/systemd](https://github.com/fedora-iot/fido-device-onboard-rs/blob/main/examples/systemd/fdo-owner-onboarding-server.service).
@@ -567,7 +567,7 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
 ### Rendezvous Server
 
 1. Configure `rendezvous-server.yml`, see [Configuration
-   Files/rendezvous_server.yml](#rendezvous_serveryml) and place it either in
+   Files/rendezvous-server.yml](#rendezvous-serveryml) and place it either in
    `/usr/share/fdo`, `/etc/fdo/` or `/etc/fdo/rendezvous-server.conf.d/`. The
    paths will be checked in that same order.
 
@@ -577,7 +577,7 @@ Please mind how the configuration file must be specifically named (e.g. `-` VS
 ### Service Info API Server
 
 1. Configure `serviceinfo-api-server.yml`, see [Configuration
-   Files/serviceinfo_api_server.yml](#serviceinfo_api_serveryml), and place it either in
+   Files/serviceinfo-api-server.yml](#serviceinfo-api-serveryml), and place it either in
    `/usr/share/fdo`, `/etc/fdo/` or `/etc/fdo/serviceinfo-api-server.conf.d/`. The
    paths will be checked in that same order.
 
@@ -747,9 +747,9 @@ still required to be set by the user (`DI_SIGN_KEY_PATH`, `DI_HMAC_KEY_PATH`).
 
   Using this feature the user can choose to apply different serviceinfo settings on different devices.
   For that the user needs to provide a path to a `per-device serviceinfo` file under the `device_specific_store_driver` field
-  present in the `serviceinfo_api_server.yml` file.
+  present in the `serviceinfo-api-server.yml` file.
   If other devices do not have their `per-device serviceinfo` file under `device_specific_store_driver` they will get onboarded
-  with settings from the main file, which is `serviceinfo_api_server.yml`.
+  with settings from the main file, which is `serviceinfo-api-server.yml`.
   
   1. Initialize the device as mentioned in [How to generate an Ownership Voucher and Credential for a Device](#how-to-generate-an-ownership-voucher-ov-and-credential-for-a-device-device-initialization).
 


### PR DESCRIPTION
The configuration file names in `HOWTO.md` are inconsistent. Both the "_" and "-" syntax is used. This commit changes all occurences of the file names to the "-" syntax.